### PR TITLE
Add more actions, and also document them

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,55 @@ import 'octane-components/dist/components/PaymentSubmission/PaymentSubmission.cs
 
 ## Actions
 
-In addition to components, `octane-components` provides access to "actions", or asynchronous interactions with our API. While these complement our React components nicely, they can be used in any client-side app.
+In addition to components, `octane-components` provides access to "actions", or asynchronous interactions with our API. While these complement our React components nicely, they can be used in any client-side app. They all return Promises and work well with `await`, when available.
 
-### `subscribeCustomer(token, plan, options)`
+### `getActiveSubscription(token): Promise<PricePlan | null>`
+
+`hasPaymentInfo` is a simple action that checks for a customer's active subscription. If it's there, it resolves to the PricePlan details for that subscription. If the customer has no subscription, it resolves to `null`.
+
+**Example**
+
+```js
+import { Actions } from 'octane-components';
+const { getActiveSubscription } = Actions;
+
+const planName = 'enterprise_plan';
+
+fetch('/token')
+  .then((resp) => resp.json())
+  .then(({ token }) => getActiveSubscription(token))
+  .then((sub) =>
+    sub !== null ? alert('yeah') : alert('customer needs a subscription')
+  );
+```
+
+**Params**
+
+- `token` _(required, string)_ — A customer token.
+
+### `hasPaymentInfo(token): Promise<boolean>`
+
+`hasPaymentInfo` is a simple action that resolves to `true` if the customer has payment info, and `false` otherwise.
+
+**Example**
+
+```js
+import { Actions } from 'octane-components';
+const { hasPaymentInfo } = Actions;
+
+const planName = 'enterprise_plan';
+
+fetch('/token')
+  .then((resp) => resp.json())
+  .then(({ token }) => hasPaymentInfo(token))
+  .then((hasIt) => (hasIt ? alert('yeah') : alert('need payment info')));
+```
+
+**Params**
+
+- `token` _(required, string)_ — A customer token.
+
+### `subscribeCustomer(token, plan, options): Promise<ActiveSubscription>`
 
 `subscribeCustomer` subscribes a customer to a specific plan. It accepts a the customer token and the name of a plan, and will subscribe that customer to the version of that plan visible to octane-components.
 
@@ -181,20 +227,17 @@ const planName = 'enterprise_plan';
 
 fetch('/token')
   .then((resp) => resp.json())
-  .then((data) => {
-    const { token } = data;
-    subscribeCustomer(token, planName);
-  });
+  .then(({ token }) => subscribeCustomer(token, planName));
 ```
+
+> Note that `checkForBillingInfo` is a convenience check and does not guarantee that valid billing info will be available in the future. For example, a customer could remove their payment information, or their payment details might expire.
 
 **Params**
 
-- `token` _(required, string)_ — A customer token representing the customer you want to subscribe.
+- `token` _(required, string)_ — A customer token.
 - `plan` _(required, string)_ — The name of the plan to subscribe the customer to
 - `options` _(optional, object)_ — Optional configuration options
   - `options.checkForBillingInfo` _(optional, boolean)_ — Whether or not to verify that there is valid payment information for the customer before subscribing them. Defaults to `false`.
-
-> Note that `checkForBillingInfo` is a convenience check and does not guarantee that valid billing info will be available in the future. For example, a customer could remove their payment information, or their payment details might expire.
 
 ## Styling components
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ import 'octane-components/dist/components/PaymentSubmission/PaymentSubmission.cs
 
 In addition to components, `octane-components` provides access to "actions", or asynchronous interactions with our API. While these complement our React components nicely, they can be used in any client-side app.
 
-### `subscribeCustomer(token, plan, checkForBillingInfo)`
+### `subscribeCustomer(token, plan, options)`
 
 `subscribeCustomer` subscribes a customer to a specific plan. It accepts a the customer token and the name of a plan, and will subscribe that customer to the version of that plan visible to octane-components.
 
@@ -191,7 +191,8 @@ fetch('/token')
 
 - `token` _(required, string)_ — A customer token representing the customer you want to subscribe.
 - `plan` _(required, string)_ — The name of the plan to subscribe the customer to
-- `checkForBillingInfo` _(optional, boolean)_ — Whether or not to verify that there is valid payment information for the customer before subscribing them.
+- `options` _(optional, object)_ — Optional configuration options
+  - `options.checkForBillingInfo` _(optional, boolean)_ — Whether or not to verify that there is valid payment information for the customer before subscribing them. Defaults to `false`.
 
 > Note that `checkForBillingInfo` is a convenience check and does not guarantee that valid billing info will be available in the future. For example, a customer could remove their payment information, or their payment details might expire.
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ In addition to components, `octane-components` provides access to "actions", or 
 
 ### `getActiveSubscription(token): Promise<PricePlan | null>`
 
-`hasPaymentInfo` is a simple action that checks for a customer's active subscription. If it's there, it resolves to the PricePlan details for that subscription. If the customer has no subscription, it resolves to `null`.
+`getActiveSubscription` checks for a customer's active subscription. If it's there, it resolves to the `PricePlan` details for that subscription. If the customer has no subscription, it resolves to `null`.
 
 **Example**
 
@@ -193,7 +193,7 @@ fetch('/token')
 
 ### `hasPaymentInfo(token): Promise<boolean>`
 
-`hasPaymentInfo` is a simple action that resolves to `true` if the customer has payment info, and `false` otherwise.
+`hasPaymentInfo` resolves to `true` if the customer has payment info, and `false` otherwise.
 
 **Example**
 
@@ -215,7 +215,7 @@ fetch('/token')
 
 ### `subscribeCustomer(token, plan, options): Promise<ActiveSubscription>`
 
-`subscribeCustomer` subscribes a customer to a specific plan. It accepts a the customer token and the name of a plan, and will subscribe that customer to the version of that plan visible to octane-components.
+`subscribeCustomer` subscribes a customer to a specific plan. It accepts a customer token and the name of a plan, and will subscribe that customer to the version of that plan visible to octane-components.
 
 **Example**
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,38 @@ import 'octane-components/dist/components/PaymentSubmission/PaymentSubmission.cs
 
 ![Screenshot of the PlanPicker component](./docs/payment-submission.png)
 
+## Actions
+
+In addition to components, `octane-components` provides access to "actions", or asynchronous interactions with our API. While these complement our React components nicely, they can be used in any client-side app.
+
+### `subscribeCustomer(token, plan, checkForBillingInfo)`
+
+`subscribeCustomer` subscribes a customer to a specific plan. It accepts a the customer token and the name of a plan, and will subscribe that customer to the version of that plan visible to octane-components.
+
+**Example**
+
+```js
+import { Actions } from 'octane-components';
+const { subscribeCustomer } = Actions;
+
+const planName = 'enterprise_plan';
+
+fetch('/token')
+  .then((resp) => resp.json())
+  .then((data) => {
+    const { token } = data;
+    subscribeCustomer(token, planName);
+  });
+```
+
+**Params**
+
+- `token` _(required, string)_ — A customer token representing the customer you want to subscribe.
+- `plan` _(required, string)_ — The name of the plan to subscribe the customer to
+- `checkForBillingInfo` _(optional, boolean)_ — Whether or not to verify that there is valid payment information for the customer before subscribing them.
+
+> Note that `checkForBillingInfo` is a convenience check and does not guarantee that valid billing info will be available in the future. For example, a customer could remove their payment information, or their payment details might expire.
+
 ## Styling components
 
 By default, components are unstyled. They are decorated with classes that should make it easy to style them to match any sort of branding.

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -30,10 +30,14 @@ const App = ({ token }: Props): JSX.Element => {
       return;
     }
     setIsSubscribing(true);
-    subscribeCustomer(token, selectedPlan, true).then((data) => {
-      alert(`Customer has been subscribed to ${data.price_plan?.display_name}`);
-      location.reload();
-    });
+    subscribeCustomer(token, selectedPlan, { checkForBillingInfo: true }).then(
+      (data) => {
+        alert(
+          `Customer has been subscribed to ${data.price_plan?.display_name}`
+        );
+        location.reload();
+      }
+    );
   }, [token, selectedPlan]);
 
   const cardStyle = {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -32,9 +32,7 @@ const App = ({ token }: Props): JSX.Element => {
     setIsSubscribing(true);
     subscribeCustomer(token, selectedPlan, true).then((data) => {
       alert(`Customer has been subscribed to ${data.price_plan?.display_name}`);
-      // eslint-disable-next-line no-console
-      console.log('subscription data', data);
-      setIsSubscribing(false);
+      location.reload();
     });
   }, [token, selectedPlan]);
 

--- a/src/actions/getActiveSubscription.ts
+++ b/src/actions/getActiveSubscription.ts
@@ -1,0 +1,23 @@
+import { getCustomerActiveSubscription } from '../api/octane';
+
+import { components } from '../apiTypes';
+type PricePlan = components['schemas']['PricePlan'];
+
+/**
+ * Fetches the customer's active subscription.
+ * Resolves to the price plan for that subscription, or `null` if there is none.
+ */
+export function hasPaymentInfo(
+  customerToken: string
+): Promise<PricePlan | null> {
+  return getCustomerActiveSubscription({ token: customerToken })
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error('Something went wrong checking the payment status');
+      }
+      return response.json();
+    })
+    .then((data) => {
+      return data?.price_plan ?? null;
+    });
+}

--- a/src/actions/hasPaymentInfo.ts
+++ b/src/actions/hasPaymentInfo.ts
@@ -1,0 +1,18 @@
+import { getPaymentMethodStatus, VALID_PAYMENT_METHOD } from '../api/octane';
+
+/**
+ * Checks if the customer represented by $customerToken has valid payment info.
+ * Resolves to `true` if so, `false` if not.
+ */
+export function hasPaymentInfo(customerToken: string): Promise<boolean> {
+  return getPaymentMethodStatus({ token: customerToken })
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error('Something went wrong checking the payment status');
+      }
+      return response.json();
+    })
+    .then(({ status }) => {
+      return status === VALID_PAYMENT_METHOD;
+    });
+}

--- a/src/actions/subscribeCustomer.ts
+++ b/src/actions/subscribeCustomer.ts
@@ -11,8 +11,6 @@ export default function subscribeCustomer(
   pricePlanName: string,
   checkForBillingInfo = false
 ): Promise<ActiveSubscription> {
-  // TODO: if checkForBillingInfo is set to true, check the yet-to-be-implemented API endpoint first.
-
   const check = checkForBillingInfo
     ? getPaymentMethodStatus({ token: customerToken })
         .then((response) => {

--- a/src/actions/subscribeCustomer.ts
+++ b/src/actions/subscribeCustomer.ts
@@ -6,11 +6,17 @@ import {
 import { components } from '../apiTypes';
 type ActiveSubscription = components['schemas']['CustomerPortalSubscription'];
 
+export interface SubscribeCustomerOptions {
+  checkForBillingInfo?: boolean;
+}
+
 export default function subscribeCustomer(
   customerToken: string,
   pricePlanName: string,
-  checkForBillingInfo = false
+  options: SubscribeCustomerOptions = {}
 ): Promise<ActiveSubscription> {
+  const { checkForBillingInfo = false } = options;
+
   const check = checkForBillingInfo
     ? getPaymentMethodStatus({ token: customerToken })
         .then((response) => {

--- a/src/components/PaymentSubmission/PaymentSubmission.tsx
+++ b/src/components/PaymentSubmission/PaymentSubmission.tsx
@@ -8,11 +8,8 @@ import {
 import { API_BASE } from '../../config';
 import { StripeApiFactory } from '../../api/stripe';
 
-import {
-  createStripeSetupIntent,
-  getPaymentMethodStatus,
-  VALID_PAYMENT_METHOD,
-} from '../../api/octane';
+import { createStripeSetupIntent } from '../../api/octane';
+import { hasPaymentInfo } from '../../actions/hasPaymentInfo';
 import { components } from '../../apiTypes';
 import { TokenProvider } from '../../hooks/useCustomerToken';
 import PropTypes from 'prop-types';
@@ -119,28 +116,17 @@ export function PaymentSubmission({
   const [isUpdatingPayment, setIsUpdatingPayment] = useState<boolean | null>(
     null
   );
-  // const [hasPayment, setHasPayment] = useState<boolean | null>(null);
   const [creds, setCreds] = useState<CustomerPortalStripeCredential | null>(
     null
   );
 
   useEffect(() => {
-    getPaymentMethodStatus({ token })
-      .then((result) => {
-        if (!result.ok) {
-          throw new Error(
-            `An error occurred fetching payment method status: ${result.statusText}`
-          );
-        }
-        return result.json();
-      })
-      .then((data) => {
-        const hasPayment = data.status === VALID_PAYMENT_METHOD;
-        setIsUpdatingPayment(!hasPayment);
-        if (hasPayment) {
-          onPaymentSet && onPaymentSet();
-        }
-      });
+    hasPaymentInfo(token).then((hasIt) => {
+      setIsUpdatingPayment(!hasIt);
+      if (hasIt) {
+        onPaymentSet && onPaymentSet();
+      }
+    });
   }, [token, setIsUpdatingPayment, onPaymentSet]);
 
   // Fetch a Stripe intent if we are updating the payment method.


### PR DESCRIPTION
This PR adds two more actions:
1. `hasPaymentInfo` and
2. `getActiveSubscription`

These are documented in the README as well. If there's missing context for this PR that isn't in that README, let me know and I'll update the README.