### PR TITLE
Make a wrapped Stripe Elements component

### DIFF
--- a/src/components/PaymentSubmission/StripeElements.tsx
+++ b/src/components/PaymentSubmission/StripeElements.tsx
@@ -1,0 +1,83 @@
+import { Elements } from '@stripe/react-stripe-js';
+import assert from 'assert';
+import React, { useState, useEffect, useContext } from 'react';
+import type { FunctionComponent } from 'react';
+import { API_BASE } from '../../config';
+import { StripeApiFactory } from '../../api/stripe';
+import { createStripeSetupIntent } from '../../api/octane';
+import { components } from '../../apiTypes';
+type CustomerPortalStripeCredential =
+  components['schemas']['CustomerPortalStripeCredential'];
+
+export const StripeClientSecretContext = React.createContext<
+  string | undefined
+>(undefined);
+
+/**
+ * Gets a Stripe client secret for the payment intent created by the
+ * StripeElements component. This hook must be called from children of the
+ * StripeElements component, which is exported from this file.
+ */
+export const useStripeClientSecret = (): string => {
+  const secret = useContext(StripeClientSecretContext);
+
+  assert(
+    secret !== undefined,
+    'Expected non-null Stripe Client Secret. Double-check that you are wrapping your component tree with `StripeElements`'
+  );
+  return secret;
+};
+
+interface StripeElementsProps {
+  customerToken: string;
+}
+
+/**
+ * This component is identical to Stripe's Elements component, but accepts an
+ * Octane customer token instead. We use this token to instantiate a payment
+ * intent and fetch all the required credentials to make the request possible.
+ *
+ * Children of this component can use the `useStripeClientSecret()` hook,
+ * exported in this file, to access the client secret.
+ */
+export const StripeElements: FunctionComponent<StripeElementsProps> = ({
+  customerToken,
+  children,
+}) => {
+  const [creds, setCreds] = useState<CustomerPortalStripeCredential | null>(
+    null
+  );
+  useEffect(() => {
+    createStripeSetupIntent({
+      token: customerToken,
+      urlOverride: API_BASE,
+    })
+      .then((result) => {
+        if (!result.ok) {
+          console.error(result);
+          throw new Error(`An error occurred: ${result.statusText}`);
+        }
+        return result.json();
+      })
+      .then(setCreds);
+  }, [customerToken]);
+
+  if (creds === null) {
+    return null;
+  }
+  const {
+    client_secret: clientSecret,
+    publishable_key: platformApiKey,
+    account_id: stripeAccount,
+  } = creds;
+
+  const stripePromise = StripeApiFactory({ platformApiKey, stripeAccount });
+
+  return (
+    <StripeClientSecretContext.Provider value={clientSecret}>
+      <Elements stripe={stripePromise} options={{ clientSecret }}>
+        {children}
+      </Elements>
+    </StripeClientSecretContext.Provider>
+  );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,10 @@ export { PaymentSubmission } from './components/PaymentSubmission/PaymentSubmiss
 // Helper components (must be wrapped with TokenProvider)
 export { MeteredComponent } from './components/PlanPicker/MeteredComponent';
 export { PricePlanCard } from './components/PlanPicker/PricePlanCard';
+export {
+  StripeElements,
+  useStripeClientSecret,
+} from './components/PaymentSubmission/StripeElements';
 
 // Token provider
 export { TokenProvider } from './hooks/useCustomerToken';


### PR DESCRIPTION
Stripe has a top-level wrapper component called `Elements`. We initialize it manually for the PaymentSubmission component using just the customer token, but we currently only do this to initialize a `CardElement`. It would be nice to expose this initialization behavior for others so that any Stripe components could be wrapped. The benefit here is that Octane users can do all this with just their Octane customer token without worrying about also juggling Stripe tokens as well.

## In this PR
* I abstracted this behavior into a new `StripeElements` component.
* I added a context for the Stripe customer secret, which is needed for Stripe API calls.
* I use them both in PaymentSubmission, which is a bit neater now.
