### PR TITLE
Prepare for hooks, add onError support.

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -33,3 +33,17 @@ yarn serve
 ```
 
 By default, the app runs at `http://localhost:3456`.
+
+## Developing locally
+
+If you're developing in octane-portal and you want to test your changes in the example app:
+
+```sh
+# In the root of this repo, make a fresh build with your changes
+yarn build
+# In the example/ directory, rebuild the app (optionally in watch mode)
+cd example
+yarn watch
+# In a separate shell, start the example web server
+yarn serve
+```

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -6,6 +6,9 @@ const { subscribeCustomer } = Actions;
 interface Props {
   token: string;
 }
+function onError(err: unknown): void {
+  console.error('Error!', err);
+}
 
 const App = ({ token }: Props): JSX.Element => {
   const [selectedPlan, setSelectedPlan] = useState<string | null>(null);
@@ -65,12 +68,17 @@ const App = ({ token }: Props): JSX.Element => {
 
   return (
     <div id='example-root'>
-      <PlanPicker customerToken={token} onPlanSelect={onPlanSelect} />
+      <PlanPicker
+        customerToken={token}
+        onPlanSelect={onPlanSelect}
+        onError={onError}
+      />
       {selectedPlan != null && (
         <PaymentSubmission
           customerToken={token}
           onPaymentSet={onPaymentSet}
           options={stripeOptions}
+          onError={onError}
         />
       )}
       {hasPayment && (

--- a/src/actions/getActiveSubscription.ts
+++ b/src/actions/getActiveSubscription.ts
@@ -7,7 +7,7 @@ type PricePlan = components['schemas']['PricePlan'];
  * Fetches the customer's active subscription.
  * Resolves to the price plan for that subscription, or `null` if there is none.
  */
-export function getActiveSubscription(
+export default function getActiveSubscription(
   customerToken: string
 ): Promise<PricePlan | null> {
   return getCustomerActiveSubscription({ token: customerToken })

--- a/src/actions/hasPaymentInfo.ts
+++ b/src/actions/hasPaymentInfo.ts
@@ -4,7 +4,9 @@ import { getPaymentMethodStatus, VALID_PAYMENT_METHOD } from '../api/octane';
  * Checks if the customer represented by $customerToken has valid payment info.
  * Resolves to `true` if so, `false` if not.
  */
-export function hasPaymentInfo(customerToken: string): Promise<boolean> {
+export default function hasPaymentInfo(
+  customerToken: string
+): Promise<boolean> {
   return getPaymentMethodStatus({ token: customerToken })
     .then((response) => {
       if (!response.ok) {

--- a/src/actions/subscribeCustomer.ts
+++ b/src/actions/subscribeCustomer.ts
@@ -1,6 +1,6 @@
 import { updateSubscription } from '../api/octane';
 import { components } from '../apiTypes';
-import { hasPaymentInfo } from './hasPaymentInfo';
+import hasPaymentInfo from './hasPaymentInfo';
 type ActiveSubscription = components['schemas']['CustomerPortalSubscription'];
 
 export interface SubscribeCustomerOptions {

--- a/src/components/PaymentSubmission/PaymentSubmission.tsx
+++ b/src/components/PaymentSubmission/PaymentSubmission.tsx
@@ -150,10 +150,12 @@ export function PaymentSubmission({
     return loading;
   }
 
+  const handleError = managerProps.onError;
+
   return (
     <>
       <TokenProvider token={token}>
-        <StripeElements loading={loading}>
+        <StripeElements loading={loading} onError={handleError}>
           <PaymentSubmissionManager
             onPaymentSet={onPaymentSet}
             {...managerProps}

--- a/src/components/PaymentSubmission/PaymentSubmission.tsx
+++ b/src/components/PaymentSubmission/PaymentSubmission.tsx
@@ -4,7 +4,7 @@ import {
   useStripe,
   CardElementProps,
 } from '@stripe/react-stripe-js';
-import { hasPaymentInfo } from '../../actions/hasPaymentInfo';
+import hasPaymentInfo from '../../actions/hasPaymentInfo';
 import { TokenProvider } from '../../hooks/useCustomerToken';
 import PropTypes from 'prop-types';
 import React, { useCallback, useState, useEffect } from 'react';
@@ -12,6 +12,7 @@ import { StripeElements, useStripeClientSecret } from './StripeElements';
 
 interface ManagerProps extends CardElementProps {
   onPaymentSet?: () => void;
+  onError?: (err: unknown) => void;
   /**
    * Text to show on the "save payment" button. Defaults to "Save".
    */
@@ -20,6 +21,7 @@ interface ManagerProps extends CardElementProps {
 
 function PaymentSubmissionManager({
   onPaymentSet: onSubmit,
+  onError,
   saveButtonText = 'SAVE',
   options,
   ...cardProps
@@ -64,12 +66,12 @@ function PaymentSubmissionManager({
         }
         onSubmit && onSubmit();
       } catch (err) {
-        console.error(err);
+        onError && onError(err);
       } finally {
         setIsSubmitting(false);
       }
     },
-    [stripe, elements, isSubmitting, clientSecret, onSubmit]
+    [stripe, elements, isSubmitting, clientSecret, onSubmit, onError]
   );
 
   const cardOptions = { disabled: isSubmitting, ...options };

--- a/src/components/PaymentSubmission/StripeElements.tsx
+++ b/src/components/PaymentSubmission/StripeElements.tsx
@@ -70,7 +70,7 @@ export const StripeElements: FunctionComponent<StripeElementsProps> = ({
     if (onError) {
       req.catch(onError);
     }
-  }, [token]);
+  }, [token, onError]);
 
   // Render the loading element if one is provided.
   if (creds === null) {

--- a/src/components/PaymentSubmission/StripeElements.tsx
+++ b/src/components/PaymentSubmission/StripeElements.tsx
@@ -33,6 +33,7 @@ interface StripeElementsProps {
    *  @see: https://stripe.com/docs/js/elements_object/create#stripe_elements-options-clientSecret
    */
   loading?: React.ReactElement;
+  onError?: (err: unknown) => void;
 }
 
 /**
@@ -45,6 +46,7 @@ interface StripeElementsProps {
  */
 export const StripeElements: FunctionComponent<StripeElementsProps> = ({
   loading = null,
+  onError,
   children,
 }) => {
   const { token } = useCustomerToken();
@@ -53,7 +55,7 @@ export const StripeElements: FunctionComponent<StripeElementsProps> = ({
   );
 
   useEffect(() => {
-    createStripeSetupIntent({
+    const req = createStripeSetupIntent({
       token,
       urlOverride: API_BASE,
     })
@@ -65,6 +67,9 @@ export const StripeElements: FunctionComponent<StripeElementsProps> = ({
         return result.json();
       })
       .then(setCreds);
+    if (onError) {
+      req.catch(onError);
+    }
   }, [token]);
 
   // Render the loading element if one is provided.

--- a/src/components/PlanPicker/PlanPicker.tsx
+++ b/src/components/PlanPicker/PlanPicker.tsx
@@ -22,6 +22,11 @@ interface PricePlanManagerProps {
    * Callback triggered whenever a plan is selected.
    */
   onPlanSelect?: (planName: string, plan: PricePlan) => void;
+  /**
+   * Error handler. Called if the request for the list of price plans fails, or
+   * if the request for the customer's active subscription fails.
+   */
+  onError?: (err: unknown) => void;
 }
 
 export interface PlanPickerProps extends PricePlanManagerProps {
@@ -44,6 +49,7 @@ function planEquals(plan1: PricePlan, plan2: PricePlan | null): boolean {
 
 function PricePlanManager({
   onPlanSelect,
+  onError,
 }: PricePlanManagerProps): JSX.Element {
   // The plans to pick from
   const [pricePlans, setPricePlans] = useState<PricePlan[]>([]);
@@ -96,10 +102,21 @@ function PricePlanManager({
 
     setLoading('loading');
 
-    Promise.all([fetchActiveSubscription(), fetchPricePlans()]).then(() => {
-      setLoading('loaded');
-    });
-  }, [onSelectPlanName, setLoading, setPricePlans, setSelectedPlan, token]);
+    Promise.all([fetchActiveSubscription(), fetchPricePlans()])
+      .then(() => {
+        setLoading('loaded');
+      })
+      .catch((err) => {
+        onError && onError(err);
+      });
+  }, [
+    onSelectPlanName,
+    setLoading,
+    setPricePlans,
+    setSelectedPlan,
+    token,
+    onError,
+  ]);
 
   return (
     <div className='octane-component price-plan-picker'>

--- a/src/hooks/useAsync.ts
+++ b/src/hooks/useAsync.ts
@@ -1,0 +1,63 @@
+// Based on https://usehooks.com/useAsync/
+import { useState, useEffect } from 'react';
+import { getPaymentMethodStatus } from '../api/octane';
+
+type UseAsyncReturnType<Result, Error> =
+  | {
+      loading: true;
+      result: null;
+      error: null;
+    }
+  | {
+      loading: false;
+      result: Result;
+      error: null;
+    }
+  | {
+      loading: false;
+      result: null;
+      error: Error;
+    };
+
+/**
+ * Given a function that returns a promise, provide a hook that exposes the
+ * promise's result, error, and loading state. This hook takes advantage of
+ * discriminated TypeScript unions for its return type; if `loading` is true,
+ * then `error` and `null` are necessarily `null`. If `loading` or `error` are
+ * null
+ */
+const useAsync = <Result, Error>(
+  asyncFn: () => Promise<Result>
+): UseAsyncReturnType<Result, Error> => {
+  const [result, setResult] = useState<UseAsyncReturnType<Result, Error>>({
+    loading: true,
+    result: null,
+    error: null,
+  });
+
+  useEffect(() => {
+    asyncFn()
+      .then((result) => {
+        setResult({ result, error: null, loading: false });
+      })
+      .catch((error) => {
+        setResult({ result: null, error, loading: false });
+      });
+  }, [asyncFn]);
+
+  return result;
+
+  // Loading is false but result hasn't been set;
+};
+
+export default useAsync;
+
+export const createApiHook = <Args extends unknown[], Result>(
+  apiMethod: (...args: Args) => Promise<Result>
+) => {
+  return function useApiHook(...args: Args) {
+    return useAsync(() => apiMethod(...args));
+  };
+};
+
+export const usePaymentMethodStatus = createApiHook(getPaymentMethodStatus);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,8 +7,12 @@ import { components } from './apiTypes';
 
 // Actions
 import subscribeCustomer from './actions/subscribeCustomer';
+import getActiveSubscription from './actions/getActiveSubscription';
+import hasPaymentInfo from './actions/hasPaymentInfo';
 export const Actions = {
   subscribeCustomer,
+  getActiveSubscription,
+  hasPaymentInfo,
 };
 
 // Top-level API components. These only need a customer token and should


### PR DESCRIPTION
This PR does a few things:

1. It refactors `api/octane` so that the URL factories aren't the things that hold the types for what the URL might return. The same url, called with different HTTP verbs, may have different return types, so this pattern didn't make sense.
2. It adds a `useAsync` helper with a sample `usePaymentMethodStatus` hook in preparation for a larger move to build these components off of a central hook library.
3. It exposes a few actions that were documented, but not officially exposed through the package API.
4. It adds support for `onError` handlers for all of our top-level components. 