### PR TITLE
Vlad eng 1167

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@storybook/addon-links": "^6.4.7",
     "@storybook/react": "^6.4.7",
     "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.5.0",
+    "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^7.2.1",
     "@types/jest": "^27.0.3",
     "@types/node": "^12.12.38",

--- a/src/actions/getActiveSubscription.ts
+++ b/src/actions/getActiveSubscription.ts
@@ -13,7 +13,7 @@ export default function getActiveSubscription(
   return getCustomerActiveSubscription({ token: customerToken })
     .then((response) => {
       if (!response.ok) {
-        throw new Error('Something went wrong checking the payment status');
+        throw new Error('Something went wrong checking active subscription');
       }
       return response.json();
     })

--- a/src/actions/getActiveSubscription.ts
+++ b/src/actions/getActiveSubscription.ts
@@ -17,7 +17,9 @@ export default function getActiveSubscription(
   return getCustomerActiveSubscription({ token: customerToken })
     .then((response) => {
       if (!response.ok) {
-        throw new Error('Something went wrong checking active subscription');
+        throw new Error(
+          'Something went wrong fetching the active subscription data'
+        );
       }
       return response.json();
     })

--- a/src/actions/getActiveSubscription.ts
+++ b/src/actions/getActiveSubscription.ts
@@ -10,6 +10,10 @@ type PricePlan = components['schemas']['PricePlan'];
 export default function getActiveSubscription(
   customerToken: string
 ): Promise<PricePlan | null> {
+  if (!customerToken) {
+    throw new Error('Token must be provided.');
+  }
+
   return getCustomerActiveSubscription({ token: customerToken })
     .then((response) => {
       if (!response.ok) {

--- a/src/actions/getAllPricePlans.test.ts
+++ b/src/actions/getAllPricePlans.test.ts
@@ -1,0 +1,46 @@
+import { enableFetchMocks } from 'jest-fetch-mock';
+import getAllPricePlans from './getAllPricePlans';
+
+enableFetchMocks();
+fetchMock.enableMocks();
+
+const mockPricePlans = [
+  {
+    displayName: 'Test Price Plan',
+    name: 'test_price_plan',
+    period: 'quarter',
+    basePrice: 100,
+  },
+];
+
+describe('getAllPricePlans', () => {
+  beforeAll(() => {
+    jest.spyOn(console, 'error');
+  });
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should throw an error if token is not provided', async () => {
+    fetchMock.once(JSON.stringify({ price_plans: mockPricePlans }));
+
+    try {
+      await getAllPricePlans('');
+    } catch (err) {
+      expect(err).toEqual(Error('Token must be provided.'));
+    }
+  });
+
+  it('should return price plans correctly', async () => {
+    fetchMock.once(JSON.stringify({ price_plans: mockPricePlans }));
+
+    const result = await getAllPricePlans('mock token');
+    expect(fetchMock.mock.calls.length).toEqual(1);
+    expect(result).toEqual({ price_plans: mockPricePlans });
+  });
+});

--- a/src/actions/getAllPricePlans.ts
+++ b/src/actions/getAllPricePlans.ts
@@ -9,6 +9,10 @@ type PricePlan = components['schemas']['PricePlan'];
 export default function getAllPricePlans(
   customerToken: string
 ): Promise<PricePlan[]> {
+  if (!customerToken) {
+    throw new Error('Token must be provided.');
+  }
+
   return getPricePlans({ token: customerToken })
     .then((response) => {
       if (!response.ok) {
@@ -17,6 +21,6 @@ export default function getAllPricePlans(
       return response.json();
     })
     .then((pricePlans) => {
-      return pricePlans ?? [];
+      return pricePlans;
     });
 }

--- a/src/actions/getAllPricePlans.ts
+++ b/src/actions/getAllPricePlans.ts
@@ -1,0 +1,22 @@
+import { getPricePlans } from '../api/octane';
+import { components } from '../apiTypes';
+
+type PricePlan = components['schemas']['PricePlan'];
+
+/**
+ * Get all price plans associated with a vendor.
+ */
+export default function getAllPricePlans(
+  customerToken: string
+): Promise<PricePlan[]> {
+  return getPricePlans({ token: customerToken })
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error('Something went wrong with getting price plans');
+      }
+      return response.json();
+    })
+    .then((pricePlans) => {
+      return pricePlans ?? [];
+    });
+}

--- a/src/actions/getPaymentMethodStatus.test.ts
+++ b/src/actions/getPaymentMethodStatus.test.ts
@@ -1,0 +1,41 @@
+import { enableFetchMocks } from 'jest-fetch-mock';
+import getPaymentMethodStatus from './getPaymentMethodStatus';
+
+enableFetchMocks();
+fetchMock.enableMocks();
+
+const paymentStatus = {
+  status: 'mock status',
+};
+
+describe('getPaymentMethodStatus', () => {
+  beforeAll(() => {
+    jest.spyOn(console, 'error');
+  });
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should throw an error if token is not provided', async () => {
+    fetchMock.once(JSON.stringify({ status: paymentStatus }));
+
+    try {
+      await getPaymentMethodStatus('');
+    } catch (err) {
+      expect(err).toEqual(Error('Token must be provided.'));
+    }
+  });
+
+  it('should return payment status correctly', async () => {
+    fetchMock.once(JSON.stringify(paymentStatus));
+
+    const result = await getPaymentMethodStatus('mock token');
+    expect(fetchMock.mock.calls.length).toEqual(1);
+    expect(result).toEqual(paymentStatus);
+  });
+});

--- a/src/actions/getPaymentMethodStatus.ts
+++ b/src/actions/getPaymentMethodStatus.ts
@@ -1,0 +1,23 @@
+import { getPaymentMethodStatus } from '../api/octane';
+import { components } from '../apiTypes';
+
+type CustomerPaymentMethodStatus =
+  components['schemas']['CustomerPaymentMethodStatus'];
+
+/**
+ * Get customer's payment method status.
+ */
+export default function getCustomerPaymentMethodStatus(
+  customerToken: string
+): Promise<CustomerPaymentMethodStatus | null> {
+  return getPaymentMethodStatus({ token: customerToken })
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error('Something went wrong checking the payment status');
+      }
+      return response.json();
+    })
+    .then((status) => {
+      return status ?? null;
+    });
+}

--- a/src/actions/getPaymentMethodStatus.ts
+++ b/src/actions/getPaymentMethodStatus.ts
@@ -10,6 +10,10 @@ type CustomerPaymentMethodStatus =
 export default function getCustomerPaymentMethodStatus(
   customerToken: string
 ): Promise<CustomerPaymentMethodStatus | null> {
+  if (!customerToken) {
+    throw new Error('Token must be provided.');
+  }
+
   return getPaymentMethodStatus({ token: customerToken })
     .then((response) => {
       if (!response.ok) {

--- a/src/actions/hasPaymentInfo.ts
+++ b/src/actions/hasPaymentInfo.ts
@@ -7,6 +7,10 @@ import { getPaymentMethodStatus, VALID_PAYMENT_METHOD } from '../api/octane';
 export default function hasPaymentInfo(
   customerToken: string
 ): Promise<boolean> {
+  if (!customerToken) {
+    throw new Error('Token must be provided.');
+  }
+
   return getPaymentMethodStatus({ token: customerToken })
     .then((response) => {
       if (!response.ok) {

--- a/src/actions/subscribeCustomer.ts
+++ b/src/actions/subscribeCustomer.ts
@@ -20,6 +20,10 @@ export default function subscribeCustomer(
   pricePlanName: string,
   options: SubscribeCustomerOptions = {}
 ): Promise<ActiveSubscription> {
+  if (!customerToken) {
+    throw new Error('Token must be provided.');
+  }
+
   const { checkForBillingInfo = false } = options;
 
   const check = checkForBillingInfo

--- a/src/hooks/useActiveSubscription.tsx
+++ b/src/hooks/useActiveSubscription.tsx
@@ -15,12 +15,11 @@ const useActiveSubscription = (args?: {
   token?: string;
 }): UseActiveSubscriptionReturnType => {
   const { token: tokenFromContext } = useContext(TokenContext);
+  const userToken = args?.token || tokenFromContext;
 
-  if (!args?.token && !tokenFromContext) {
+  if (!userToken) {
     throw new Error('Token must be provided.');
   }
-
-  const userToken = args?.token || tokenFromContext;
 
   const asyncFunc = useCallback(() => {
     return getActiveSubscription(userToken);

--- a/src/hooks/useHasPaymentInfo.test.tsx
+++ b/src/hooks/useHasPaymentInfo.test.tsx
@@ -1,0 +1,77 @@
+/* eslint-disable dot-notation */
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { enableFetchMocks } from 'jest-fetch-mock';
+import { VALID_PAYMENT_METHOD } from 'api/octane';
+import * as getPaymentMethodStatus from 'actions/getPaymentMethodStatus';
+import useHasPaymentInfo from './useHasPaymentInfo';
+import { TokenProvider } from './useCustomerToken';
+
+enableFetchMocks();
+fetchMock.enableMocks();
+
+const validStatus = {
+  status: VALID_PAYMENT_METHOD,
+};
+
+const invalidStatus = {
+  status: 'invalid',
+};
+
+let hookResult: boolean | null;
+
+const MockComponent = (props?: { token?: string }): JSX.Element => {
+  const result = useHasPaymentInfo({
+    token: props?.token,
+  });
+
+  hookResult = result;
+
+  return <></>;
+};
+
+describe('useHasPaymentInfo hook', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    fetchMock.resetMocks();
+    hookResult = null;
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns `true` if status is valid', async () => {
+    const mockToken = '12345';
+    fetchMock.once(JSON.stringify(validStatus));
+    const spy = jest.spyOn(getPaymentMethodStatus, 'default');
+
+    render(
+      <TokenProvider token={mockToken}>
+        <MockComponent />
+      </TokenProvider>
+    );
+
+    await waitFor(() => expect(spy).toHaveBeenCalledWith(mockToken));
+    expect(fetchMock.mock.calls.length).toEqual(1);
+    expect(fetchMock.mock.calls[0]?.[1]?.headers?.['Authorization']).toBe(
+      `Bearer ${mockToken}`
+    );
+    expect(hookResult).toBeTruthy();
+  });
+
+  it('returns `false` if status is valid', async () => {
+    const mockToken = '12345';
+    fetchMock.once(JSON.stringify(invalidStatus));
+    const spy = jest.spyOn(getPaymentMethodStatus, 'default');
+
+    render(
+      <TokenProvider token={mockToken}>
+        <MockComponent />
+      </TokenProvider>
+    );
+
+    await waitFor(() => expect(spy).toHaveBeenCalledWith(mockToken));
+    expect(hookResult).toBeFalsy();
+  });
+});

--- a/src/hooks/useHasPaymentInfo.tsx
+++ b/src/hooks/useHasPaymentInfo.tsx
@@ -1,0 +1,9 @@
+import usePaymentMethodStatus from 'hooks/usePaymentMethodStatus';
+import { VALID_PAYMENT_METHOD } from 'api/octane';
+
+const useHasPaymentInfo = (args?: { token?: string }): boolean => {
+  const { result: paymentInfo } = usePaymentMethodStatus(args);
+  return paymentInfo?.status === VALID_PAYMENT_METHOD;
+};
+
+export default useHasPaymentInfo;

--- a/src/hooks/usePaymentMethodStatus.test.tsx
+++ b/src/hooks/usePaymentMethodStatus.test.tsx
@@ -2,25 +2,23 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { enableFetchMocks } from 'jest-fetch-mock';
+import { VALID_PAYMENT_METHOD } from 'api/octane';
+import * as getPaymentMethodStatus from 'actions/getPaymentMethodStatus';
+import usePaymentMethodStatus from './usePaymentMethodStatus';
+import type { UsePaymentMethodStatusReturnType } from './usePaymentMethodStatus';
 import { TokenProvider } from './useCustomerToken';
-import useActiveSubscription from './useActiveSubscription';
-import type { UseActiveSubscriptionReturnType } from './useActiveSubscription';
-import * as getActiveSubscription from 'actions/getActiveSubscription';
 
 enableFetchMocks();
 fetchMock.enableMocks();
 
-const mockPricePlan = {
-  displayName: 'Test Price Plan',
-  name: 'test_price_plan',
-  period: 'quarter',
-  basePrice: 100,
+const paymentStatus = {
+  status: VALID_PAYMENT_METHOD,
 };
 
-let hookResult: UseActiveSubscriptionReturnType | null;
+let hookResult: UsePaymentMethodStatusReturnType | null;
 
 const MockComponent = (props?: { token?: string }): JSX.Element => {
-  const result = useActiveSubscription({
+  const result = usePaymentMethodStatus({
     token: props?.token,
   });
 
@@ -29,9 +27,9 @@ const MockComponent = (props?: { token?: string }): JSX.Element => {
   return <></>;
 };
 
-describe('useActiveSubscription hook', () => {
+describe('usePaymentMethodStatus hook', () => {
   beforeEach(() => {
-    fetchMock.once(JSON.stringify({ price_plan: mockPricePlan }));
+    fetchMock.once(JSON.stringify(paymentStatus));
   });
 
   afterEach(() => {
@@ -46,7 +44,7 @@ describe('useActiveSubscription hook', () => {
 
   it('is called correctly with a token from context', async () => {
     const mockToken = '12345';
-    const spy = jest.spyOn(getActiveSubscription, 'default');
+    const spy = jest.spyOn(getPaymentMethodStatus, 'default');
 
     render(
       <TokenProvider token={mockToken}>
@@ -59,14 +57,14 @@ describe('useActiveSubscription hook', () => {
     expect(fetchMock.mock.calls[0]?.[1]?.headers?.['Authorization']).toBe(
       `Bearer ${mockToken}`
     );
-    expect(hookResult?.result).toEqual(mockPricePlan);
+    expect(hookResult?.result).toEqual(paymentStatus);
     expect(hookResult?.loading).toBeDefined();
     expect(hookResult?.error).toBeDefined();
   });
 
   it('is called correctly with token passed in directly', async () => {
     const mockToken = '54321';
-    const spy = jest.spyOn(getActiveSubscription, 'default');
+    const spy = jest.spyOn(getPaymentMethodStatus, 'default');
 
     render(<MockComponent token={mockToken} />);
 
@@ -75,7 +73,7 @@ describe('useActiveSubscription hook', () => {
     expect(fetchMock.mock.calls[0]?.[1]?.headers?.['Authorization']).toBe(
       `Bearer ${mockToken}`
     );
-    expect(hookResult?.result).toEqual(mockPricePlan);
+    expect(hookResult?.result).toEqual(paymentStatus);
     expect(hookResult?.loading).toBeDefined();
     expect(hookResult?.error).toBeDefined();
   });
@@ -83,7 +81,7 @@ describe('useActiveSubscription hook', () => {
   it('should prefer token, which passed in directly', async () => {
     const tokenAsArgument = '12345';
     const tokenFromContext = '54321';
-    const spy = jest.spyOn(getActiveSubscription, 'default');
+    const spy = jest.spyOn(getPaymentMethodStatus, 'default');
 
     render(
       <TokenProvider token={tokenFromContext}>

--- a/src/hooks/usePaymentMethodStatus.tsx
+++ b/src/hooks/usePaymentMethodStatus.tsx
@@ -1,0 +1,34 @@
+import { useCallback, useContext } from 'react';
+import getPaymentMethodStatus from 'actions/getPaymentMethodStatus';
+import useAsync from 'hooks/useAsync';
+import type { UseAsyncReturnType } from 'hooks/useAsync';
+import { TokenContext } from 'hooks/useCustomerToken';
+import { components } from '../apiTypes';
+
+type CustomerPaymentMethodStatus =
+  components['schemas']['CustomerPaymentMethodStatus'];
+export type UsePaymentMethodStatusReturnType =
+  UseAsyncReturnType<CustomerPaymentMethodStatus>;
+
+/**
+ * A hook that fetches customer's payment method status.
+ */
+const usePaymentMethodStatus = (args?: {
+  token?: string;
+}): UsePaymentMethodStatusReturnType => {
+  const { token: tokenFromContext } = useContext(TokenContext);
+
+  if (!args?.token && !tokenFromContext) {
+    throw new Error('Token must be provided.');
+  }
+
+  const userToken = args?.token || tokenFromContext;
+
+  const asyncFunc = useCallback(() => {
+    return getPaymentMethodStatus(userToken);
+  }, [userToken]);
+
+  return useAsync(asyncFunc);
+};
+
+export default usePaymentMethodStatus;

--- a/src/hooks/usePaymentMethodStatus.tsx
+++ b/src/hooks/usePaymentMethodStatus.tsx
@@ -17,12 +17,11 @@ const usePaymentMethodStatus = (args?: {
   token?: string;
 }): UsePaymentMethodStatusReturnType => {
   const { token: tokenFromContext } = useContext(TokenContext);
+  const userToken = args?.token || tokenFromContext;
 
-  if (!args?.token && !tokenFromContext) {
+  if (!userToken) {
     throw new Error('Token must be provided.');
   }
-
-  const userToken = args?.token || tokenFromContext;
 
   const asyncFunc = useCallback(() => {
     return getPaymentMethodStatus(userToken);

--- a/src/hooks/usePricePlans.tsx
+++ b/src/hooks/usePricePlans.tsx
@@ -1,0 +1,30 @@
+import { useCallback, useContext } from 'react';
+import getAllPricePlans from 'actions/getAllPricePlans';
+import useAsync from 'hooks/useAsync';
+import type { UseAsyncReturnType } from 'hooks/useAsync';
+import { TokenContext } from 'hooks/useCustomerToken';
+import { components } from '../apiTypes';
+
+type PricePlan = components['schemas']['PricePlan'];
+export type UsePricePlansReturnType = UseAsyncReturnType<PricePlan[]>;
+
+/**
+ * A hook that fetches all price plans associated with a vendor.
+ */
+const usePricePlans = (args?: { token?: string }): UsePricePlansReturnType => {
+  const { token: tokenFromContext } = useContext(TokenContext);
+
+  if (!args?.token && !tokenFromContext) {
+    throw new Error('Token must be provided.');
+  }
+
+  const userToken = args?.token || tokenFromContext;
+
+  const asyncFunc = useCallback(() => {
+    return getAllPricePlans(userToken);
+  }, [userToken]);
+
+  return useAsync(asyncFunc);
+};
+
+export default usePricePlans;

--- a/src/hooks/usePricePlans.tsx
+++ b/src/hooks/usePricePlans.tsx
@@ -13,12 +13,11 @@ export type UsePricePlansReturnType = UseAsyncReturnType<PricePlan[]>;
  */
 const usePricePlans = (args?: { token?: string }): UsePricePlansReturnType => {
   const { token: tokenFromContext } = useContext(TokenContext);
+  const userToken = args?.token || tokenFromContext;
 
-  if (!args?.token && !tokenFromContext) {
+  if (!userToken) {
     throw new Error('Token must be provided.');
   }
-
-  const userToken = args?.token || tokenFromContext;
 
   const asyncFunc = useCallback(() => {
     return getAllPricePlans(userToken);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1067,12 +1067,12 @@
     source-map-support "^0.5.16"
 
 "@babel/runtime-corejs3@^7.10.2":
-  version "7.19.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.19.6.tgz#778471a71d915cf3b955a9201bebabfe924f872a"
-  integrity sha512-oWNn1ZlGde7b4i/3tnixpH9qI0bOAACiUs+KEES4UUCnsPjVWFlWdLV/iwJuPC2qp3EowbAqsm+0XqNwnwYhxA==
+  version "7.20.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.20.0.tgz#56ef7af3cd23d1570969809a5a8782e774e0141a"
+  integrity sha512-v1JH7PeAAGBEyTQM9TqojVl+b20zXtesFKCJHu50xMxZKD1fX0TKaKHPsZfFkXfs7D1M9M6Eeqg1FkJ3a0x2dA==
   dependencies:
     core-js-pure "^3.25.1"
-    regenerator-runtime "^0.13.4"
+    regenerator-runtime "^0.13.10"
 
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.0.0-rc.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4":
   version "7.16.0"
@@ -1476,16 +1476,6 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@jest/types@^25.5.0":
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
-  integrity sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^15.0.0"
-    chalk "^3.0.0"
-
 "@jest/types@^26.6.2":
   version "26.6.2"
   resolved "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz"
@@ -1687,11 +1677,6 @@
     "@types/estree" "0.0.39"
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
-
-"@sheerun/mutationobserver-shim@^0.3.2":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#5405ee8e444ed212db44e79351f0c70a582aae25"
-  integrity sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -2766,32 +2751,19 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@testing-library/dom@*":
-  version "8.19.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.19.0.tgz#bd3f83c217ebac16694329e413d9ad5fdcfd785f"
-  integrity sha512-6YWYPPpxG3e/xOo6HIWwB/58HukkwIVTOaZ0VwdMVjhRUX/01E4FtQbck9GazOOj7MXHc5RBzMrU86iBJHbI+A==
+"@testing-library/dom@^7.28.1":
+  version "7.31.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.31.2.tgz#df361db38f5212b88555068ab8119f5d841a8c4a"
+  integrity sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"
     "@types/aria-query" "^4.2.0"
-    aria-query "^5.0.0"
+    aria-query "^4.2.2"
     chalk "^4.1.0"
-    dom-accessibility-api "^0.5.9"
+    dom-accessibility-api "^0.5.6"
     lz-string "^1.4.4"
-    pretty-format "^27.0.2"
-
-"@testing-library/dom@^6.15.0":
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.16.0.tgz#04ada27ed74ad4c0f0d984a1245bb29b1fd90ba9"
-  integrity sha512-lBD88ssxqEfz0wFL6MeUyyWZfV/2cjEZZV3YRpb2IoJRej/4f1jB0TzqIOznTpfR1r34CNesrubxwIlAQ8zgPA==
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-    "@sheerun/mutationobserver-shim" "^0.3.2"
-    "@types/testing-library__dom" "^6.12.1"
-    aria-query "^4.0.2"
-    dom-accessibility-api "^0.3.0"
-    pretty-format "^25.1.0"
-    wait-for-expect "^3.0.2"
+    pretty-format "^26.6.2"
 
 "@testing-library/jest-dom@^4.2.4":
   version "4.2.4"
@@ -2808,14 +2780,13 @@
     pretty-format "^24.0.0"
     redent "^3.0.0"
 
-"@testing-library/react@^9.5.0":
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-9.5.0.tgz#71531655a7890b61e77a1b39452fbedf0472ca5e"
-  integrity sha512-di1b+D0p+rfeboHO5W7gTVeZDIK5+maEgstrZbWZSSvxDyfDRkkyBE1AJR5Psd6doNldluXlCWqXriUfqu/9Qg==
+"@testing-library/react@^11.2.7":
+  version "11.2.7"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.7.tgz#b29e2e95c6765c815786c0bc1d5aed9cb2bf7818"
+  integrity sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==
   dependencies:
-    "@babel/runtime" "^7.8.4"
-    "@testing-library/dom" "^6.15.0"
-    "@types/testing-library__react" "^9.1.2"
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^7.28.1"
 
 "@testing-library/user-event@^7.2.1":
   version "7.2.1"
@@ -3075,13 +3046,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@*":
-  version "18.0.7"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.7.tgz#ee7cf8ec4e6977e3f0a7b1d38bd89c75aa2aec28"
-  integrity sha512-HaXc+BbqAZE1RdsK3tC8SbkFy6UL2xF76lT9rQs5JkPrJg3rWA3Ou/Lhw3YJQzEDkBpmJ79nBsfnd05WrBd2QQ==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-dom@^16.9.7":
   version "16.9.14"
   resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz"
@@ -3131,29 +3095,6 @@
   version "1.0.8"
   resolved "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz"
   integrity sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==
-
-"@types/testing-library__dom@*":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-7.5.0.tgz#e0a00dd766983b1d6e9d10d33e708005ce6ad13e"
-  integrity sha512-mj1aH4cj3XUpMEgVpognma5kHVtbm6U6cHZmEFzCRiXPvKkuHrFr3+yXdGLXvfFRBaQIVshPGHI+hGTOJlhS/g==
-  dependencies:
-    "@testing-library/dom" "*"
-
-"@types/testing-library__dom@^6.12.1":
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-6.14.0.tgz#1aede831cb4ed4a398448df5a2c54b54a365644e"
-  integrity sha512-sMl7OSv0AvMOqn1UJ6j1unPMIHRXen0Ita1ujnMX912rrOcawe4f7wu0Zt9GIQhBhJvH2BaibqFgQ3lP+Pj2hA==
-  dependencies:
-    pretty-format "^24.3.0"
-
-"@types/testing-library__react@^9.1.2":
-  version "9.1.3"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__react/-/testing-library__react-9.1.3.tgz#35eca61cc6ea923543796f16034882a1603d7302"
-  integrity sha512-iCdNPKU3IsYwRK9JieSYAiX0+aYDXOGAmrC/3/M7AqqSDKnWWVv07X+Zk1uFSL7cMTUYzv4lQRfohucEocn5/w==
-  dependencies:
-    "@types/react-dom" "*"
-    "@types/testing-library__dom" "*"
-    pretty-format "^25.1.0"
 
 "@types/tough-cookie@*":
   version "4.0.1"
@@ -3707,18 +3648,13 @@ argparse@^2.0.1:
   resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
-aria-query@^4.0.2:
+aria-query@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
   integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
   dependencies:
     "@babel/runtime" "^7.10.2"
     "@babel/runtime-corejs3" "^7.10.2"
-
-aria-query@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz"
-  integrity sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -5625,15 +5561,10 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-accessibility-api@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz#511e5993dd673b97c87ea47dba0e3892f7e0c983"
-  integrity sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==
-
-dom-accessibility-api@^0.5.9:
-  version "0.5.10"
-  resolved "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz"
-  integrity sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==
+dom-accessibility-api@^0.5.6:
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz#56082f71b1dc7aac69d83c4285eef39c15d93f56"
+  integrity sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -11016,7 +10947,7 @@ pretty-error@^2.1.1:
     lodash "^4.17.20"
     renderkid "^2.0.4"
 
-pretty-format@^24.0.0, pretty-format@^24.3.0, pretty-format@^24.9.0:
+pretty-format@^24.0.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
@@ -11026,17 +10957,17 @@ pretty-format@^24.0.0, pretty-format@^24.3.0, pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
-pretty-format@^25.1.0:
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
-  integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
+pretty-format@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
+  integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
   dependencies:
-    "@jest/types" "^25.5.0"
+    "@jest/types" "^26.6.2"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
-    react-is "^16.12.0"
+    react-is "^17.0.1"
 
-pretty-format@^27.0.0, pretty-format@^27.0.2, pretty-format@^27.4.0:
+pretty-format@^27.0.0, pretty-format@^27.4.0:
   version "27.4.0"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.0.tgz"
   integrity sha512-n0QR6hMREfp6nLzfVksXMAfIxk1ffOOfbb/FzKHFmRtn9iJKaZXB8WMzLr8a72IASShEAhqK06nlwp1gVWgqKg==
@@ -11458,7 +11389,7 @@ react-is@17.0.2, react-is@^17.0.1, react-is@^17.0.2:
   resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -11699,6 +11630,11 @@ regenerate@^1.4.2:
   version "1.4.2"
   resolved "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
+
+regenerator-runtime@^0.13.10:
+  version "0.13.10"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz#ed07b19616bcbec5da6274ebc75ae95634bfc2ee"
+  integrity sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==
 
 regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
   version "0.13.9"
@@ -13683,11 +13619,6 @@ w3c-xmlserializer@^2.0.0:
   integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
   dependencies:
     xml-name-validator "^3.0.0"
-
-wait-for-expect@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
-  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.8"


### PR DESCRIPTION
## Why do we need this change?

Add actions and customer hooks for GET requests:
- `usePricePlan` 
- `usePaymentMethodStatus`
- `useHasPaymentInfo`

Added tests for some actions and hooks as well.

Updated `@testing-library/react` to `11.2.7` version. This is not the latest one, but has a lot more useful features and it doesn't required newest `react: "^18.x.x"` versions.  

