### PR TITLE
Make sure we only publish when pushing to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,7 @@
-on: push
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   publish:

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ dist/
 .DS_Store
 storybook-static/
 .env.local
+.vscode/
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octane-components",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Ready-to-use React components that make it easy to integrate with Octane",
   "author": "Octane (http://getoctane.io)",
   "license": "MIT",


### PR DESCRIPTION
## Why do we need this change?

The publish script currently runs any time there is any push at all. This means that we'll publish even if we haven't merged our changes into `main`. So, opening a branch to update the npm version and then merging that branch inadvertently publishes that version twice (the second fails).

## What changes are in this PR?

1. Scope the publish script to only run on `main`
2. Add `.vscode/` to our gitignore
3. Republish v0.6.0 as v0.6.1 to pick up changes that were missed due to this double-publish bug.

## How has this change been tested?

If this PR doesn't publish v0.6.1, then we should be good.
