### PR TITLE
Update hooks functionality: added `fetch` and `update` hook functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octane-components",
-  "version": "0.14.5",
+  "version": "0.15.0",
   "description": "Ready-to-use React components that make it easy to integrate with Octane",
   "author": "Octane (http://getoctane.io)",
   "license": "MIT",

--- a/src/apiTypes.ts
+++ b/src/apiTypes.ts
@@ -497,9 +497,9 @@ export interface paths {
     get: {
       parameters: {
         path: {
+          token: string;
           invoice_id: number;
           customer_name: string;
-          token: string;
         };
       };
       responses: {
@@ -508,9 +508,9 @@ export interface paths {
     };
     parameters: {
       path: {
+        token: string;
         invoice_id: number;
         customer_name: string;
-        token: string;
       };
     };
   };
@@ -519,9 +519,9 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          customer_name: string;
-          as_of_str: string;
           token: string;
+          as_of_str: string;
+          customer_name: string;
         };
       };
       responses: {
@@ -530,9 +530,9 @@ export interface paths {
     };
     parameters: {
       path: {
-        customer_name: string;
-        as_of_str: string;
         token: string;
+        as_of_str: string;
+        customer_name: string;
       };
     };
   };
@@ -541,8 +541,8 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          customer_name: string;
           token: string;
+          customer_name: string;
         };
       };
       responses: {
@@ -551,8 +551,8 @@ export interface paths {
     };
     parameters: {
       path: {
-        customer_name: string;
         token: string;
+        customer_name: string;
       };
     };
   };
@@ -588,11 +588,11 @@ export interface paths {
           customer_name: string;
         };
         query: {
-          meter_name?: string;
-          /** Starting timestamp to consider usage formatted as ISO-8601. */
-          start_time?: string;
           /** Ending timestamp to consider usage formatted as ISO-8601. */
           end_time?: string;
+          /** Starting timestamp to consider usage formatted as ISO-8601. */
+          start_time?: string;
+          meter_name?: string;
         };
       };
       responses: {
@@ -713,17 +713,17 @@ export interface paths {
           customer_name: string;
         };
         query: {
-          /** The number of items to fetch. Defaults to 10. */
-          limit?: number;
-          sort_direction?: string;
-          sort_column?: string;
-          customer_name?: string;
           /** The sort column offset to start at when paging forwards */
           forward_sort_offset?: string;
-          start_time?: string;
-          status?: string;
+          sort_direction?: string;
+          sort_column?: string;
           /** The unique offset to start at when paging forwards */
           forward_secondary_sort_offset?: string;
+          start_time?: string;
+          customer_name?: string;
+          /** The number of items to fetch. Defaults to 10. */
+          limit?: number;
+          status?: string;
         };
       };
       responses: {
@@ -822,6 +822,33 @@ export interface paths {
     };
     parameters: {
       path: {
+        customer_name: string;
+      };
+    };
+  };
+  '/customers/{customer_name}/usage_across_meters/{token}': {
+    /** Get the usage for a customer across all meters in XLS format for a given time period. */
+    get: {
+      parameters: {
+        path: {
+          token: string;
+          customer_name: string;
+        };
+        query: {
+          start_time: string;
+          end_time: string;
+        };
+      };
+      responses: {
+        /** OK */
+        200: unknown;
+        422: components['responses']['UNPROCESSABLE_ENTITY'];
+        default: components['responses']['DEFAULT_ERROR'];
+      };
+    };
+    parameters: {
+      path: {
+        token: string;
         customer_name: string;
       };
     };
@@ -1291,17 +1318,17 @@ export interface paths {
     get: {
       parameters: {
         query: {
-          /** The number of items to fetch. Defaults to 10. */
-          limit?: number;
-          sort_direction?: string;
-          sort_column?: string;
-          customer_name?: string;
           /** The sort column offset to start at when paging forwards */
           forward_sort_offset?: string;
-          start_time?: string;
-          status?: string;
+          sort_direction?: string;
+          sort_column?: string;
           /** The unique offset to start at when paging forwards */
           forward_secondary_sort_offset?: string;
+          start_time?: string;
+          customer_name?: string;
+          /** The number of items to fetch. Defaults to 10. */
+          limit?: number;
+          status?: string;
         };
       };
       responses: {
@@ -1431,15 +1458,15 @@ export interface paths {
       parameters: {
         query: {
           tags?: string[];
-          /** The number of items to fetch. Defaults to 10. */
-          limit?: number;
-          sort_direction?: string;
-          sort_column?: string;
-          names?: string[];
           /** The sort column offset to start at when paging forwards */
           forward_sort_offset?: string;
+          sort_direction?: string;
+          sort_column?: string;
           /** The unique offset to start at when paging forwards */
           forward_secondary_sort_offset?: string;
+          names?: string[];
+          /** The number of items to fetch. Defaults to 10. */
+          limit?: number;
         };
       };
       responses: {
@@ -2244,7 +2271,11 @@ export interface paths {
     };
   };
   '/ecp/usage': {
-    /** Get the customer's daily usage by meter for current and previous billing cycles. This endpoint expects the customer-scoped token for authentication. */
+    /**
+     * [DEPRECATED] Get the customer's daily usage by meter for current and previous billing cycles. This endpoint expects the customer-scoped token for authentication.
+     *
+     * Please use /ecp/filtered_usage instead.
+     */
     get: {
       responses: {
         /** OK */
@@ -2485,8 +2516,8 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          customer_name: string;
           as_of_str: string;
+          customer_name: string;
         };
       };
       responses: {
@@ -2501,8 +2532,8 @@ export interface paths {
     };
     parameters: {
       path: {
-        customer_name: string;
         as_of_str: string;
+        customer_name: string;
       };
     };
   };
@@ -2809,16 +2840,18 @@ export interface components {
     Error: {
       /** Errors */
       errors?: { [key: string]: unknown };
+      /** Error message */
+      message?: string;
       /** Error name */
       status?: string;
       /** Error code */
       code?: number;
-      /** Error message */
-      message?: string;
     };
     Meter: {
       /** Unique name identifier */
       name: string;
+      /** Name of the event associated with this meter */
+      event_name: string;
       /** Name used for display in UI */
       display_name?: string;
       description?: string | null;
@@ -2831,35 +2864,38 @@ export interface components {
       primary_labels?: unknown[];
     };
     MeterInputArgs: {
-      expected_labels?: string[];
-      is_incremental?: boolean;
       name?: string;
-      display_name?: string;
-      primary_labels?: string[];
+      expected_labels?: string[];
       vendor_id?: number;
+      event_name?: string;
+      meter_type?: 'COUNTER' | 'GAUGE';
+      display_name?: string;
       unit_name?: string;
       description?: string;
-      meter_type?: 'COUNTER' | 'GAUGE';
+      primary_labels?: string[];
+      is_incremental?: boolean;
     };
     UpdateMeterArgs: {
-      description?: string;
       display_name?: string;
+      description?: string;
     };
     Measurement: {
+      /** The name of the event associated with this measurement. Events allow for a 1 to many relationship between measurement and meters. */
+      event_name?: string;
       /** The raw value of the measurement */
       value: number;
-      /** A set of key:value label pairs to supplement a measurement. Each meter defines its own set of primary and/or expected labels. */
-      labels?: { [key: string]: string };
-      /** An ID that is unique for the set of labels and meter_name */
-      id?: string;
-      /** The name of the customer to associate the measurement with. */
-      customer_name?: string;
       /** Applies to incremental meters and resets the total current value to this new value. */
       reset_total?: boolean;
+      /** The unique name of the meter associated with this measurement */
+      meter_name?: string;
       /** All times are parsed as `ISO-8601` formatted, UTC-based timestamps */
       time?: string;
-      /** The unique name of the meter associated with this measurement */
-      meter_name: string;
+      /** An ID that is unique for the set of labels and meter_name */
+      id?: string;
+      /** A set of key:value label pairs to supplement a measurement. Each meter defines its own set of primary and/or expected labels. */
+      labels?: { [key: string]: string };
+      /** The name of the customer to associate the measurement with. */
+      customer_name?: string;
     };
     ContactInfo: {
       address_line_1?: string | null;
@@ -2896,42 +2932,42 @@ export interface components {
       label: string;
     };
     ContactInfoInputArgs: {
-      /** List of secondary contact emails (all email communication will also be sent to these emails). */
-      secondary_emails?: string[] | null;
-      email?: string | null;
+      country?: string | null;
       address_line_2?: string | null;
+      legal_name?: string | null;
       url?: string | null;
-      vat_id?: string | null;
       address_line_1?: string | null;
       logo_url?: string | null;
-      legal_name?: string | null;
       city?: string | null;
-      country?: string | null;
-      phone?: string | null;
       zipcode?: string | null;
       state?: string | null;
+      vat_id?: string | null;
+      /** List of secondary contact emails (all email communication will also be sent to these emails). */
+      secondary_emails?: string[] | null;
+      phone?: string | null;
+      email?: string | null;
     };
     CreateCustomerArgs: {
-      tags?: string[] | null;
-      price_plan_name?: string;
-      measurement_mappings?: components['schemas']['CustomerMeasurementMappingInputArgs'][];
-      contact_info?: components['schemas']['ContactInfoInputArgs'];
-      autogenerate_payment_gateway_customer?: boolean;
-      price_plan_tag?: string;
       name?: string;
-      display_name?: string;
-      autogenerate_accounting_customer?: boolean;
+      tags?: string[] | null;
       vendor_id?: number;
+      autogenerate_accounting_customer?: boolean;
+      display_name?: string;
+      measurement_mappings?: components['schemas']['CustomerMeasurementMappingInputArgs'][];
+      price_plan_tag?: string;
       created_at?: string;
+      contact_info?: components['schemas']['ContactInfoInputArgs'];
+      price_plan_name?: string;
+      autogenerate_payment_gateway_customer?: boolean;
     };
     UpdateCustomerArgs: {
-      tags?: string[] | null;
-      measurement_mappings?: components['schemas']['CustomerMeasurementMappingInputArgs'][];
-      contact_info?: components['schemas']['ContactInfoInputArgs'];
       name?: string;
-      display_name?: string;
+      tags?: string[] | null;
       vendor_id?: number;
+      display_name?: string;
+      measurement_mappings?: components['schemas']['CustomerMeasurementMappingInputArgs'][];
       created_at?: string;
+      contact_info?: components['schemas']['ContactInfoInputArgs'];
     };
     CustomerMeasurementMapping: {
       /** The label key used to map measurements to customers. */
@@ -3021,69 +3057,69 @@ export interface components {
       alternate_sendgrid_template_id?: string | null;
     };
     CustomerBillingSettingsInputArgs: {
-      /** Flag that controls whether to do automated taxes via payment provider */
-      tax_via_payment_provider?: boolean | null;
-      /** Flag that controls the number of retry attempts for invoicing/payments. */
-      retry_attempts?: number | null;
-      /** Time length unit of the grace period between the end of invoice generation and actual charge. One of `minute`, `hour`, `day`. */
-      payment_grace_period_unit?: string | null;
-      /** Optional url of a custom image to include on invoices. */
-      invoice_logo_url?: string | null;
       customer_invoice_detail_level?: string;
-      /** If using stripe, this field can be used to configure whether invoices should be auto advanced for collection */
-      stripe_auto_advance?: boolean | null;
-      /** Flag that controls whether or not to auto-charge the customer based on the invoice. */
-      charges_enabled?: boolean | null;
-      /** Time length of the grace period between the end of invoice generation and the actual charge. *NOTE*: The specified length is unitless. Unit is designated with the `payment_grace_period_unit` field. */
-      payment_grace_period_length?: number | null;
-      /** Sets the due date on invoices to the number of days after the invoice is sent */
-      days_until_due?: number | null;
-      /** Default value for whether to align billing cycles to calendar on subscriptions */
-      align_billing_cycles_to_calendar?: boolean | null;
-      /** Flag that controls whether invoices are auto-approved or require manual approval */
-      auto_approve_invoices?: boolean | null;
-      /** True if customer updates should be synced to Stripe. */
-      sync_customer_data_to_payment_gateway?: boolean | null;
+      /** The percentage tax rate to apply to invoices. */
+      tax_rate?: number | null;
+      /** Flag that controls whether or not to invoice/charge a true up for a billing cycle on the following invoice. Only applies if invoice_fixed_components_at_start is enabled. */
+      invoice_overages?: boolean | null;
+      /** Optional description attached to the invoice */
+      invoice_memo?: string | null;
       /** Bank name for ACH/Wire transfer instructions */
       ach_bank_name?: string | null;
-      /** Swift code for ACH/Wire transfer instructions */
-      ach_swift_code?: string | null;
+      /** Account name for ACH/Wire transfer instructions */
+      ach_account_name?: string | null;
+      /** If using stripe, this field can be used to configure whether invoices should be auto advanced for collection */
+      stripe_auto_advance?: boolean | null;
+      /** Flag that controls the number of retry attempts for invoicing/payments. */
+      retry_attempts?: number | null;
+      /** Second line of bank address for ACH/Wire transfer instructions */
+      ach_bank_address_2?: string | null;
       /** Flag determining whether ACH/Wire instructions should be included on invoices. */
       include_ach_instructions?: boolean | null;
       /** Time length unit of the grace period between the end of a billing cycle and invoice generation. Must be `day`. */
       invoice_grace_period_unit?: 'day' | null;
-      /** Time length after which to attempt invoice/payment retry. */
-      retry_frequency_length?: number | null;
-      /** Time length unit after which to attempt invoice/payment retry. */
-      retry_frequency_unit?: string | null;
-      /** Flag that controls whether or not to invoice/charge the base rate, add ons and other fixed price plan components at the beginning of the billing cycle. */
-      invoice_fixed_components_at_start?: boolean | null;
-      /** Optional description attached to the invoice */
-      invoice_memo?: string | null;
+      /** Time length unit of the grace period between the end of invoice generation and actual charge. One of `minute`, `hour`, `day`. */
+      payment_grace_period_unit?: string | null;
+      /** Flag that controls whether or not invoices should be sent to customers. */
+      should_send_invoice_to_customers?: boolean | null;
       /** First line of bank address for ACH/Wire transfer instructions */
       ach_bank_address_1?: string | null;
-      /** Flag that controls whether or not to invoice/charge gauge meters upfront according to their value at start of cycle. Only applies if invoice_fixed_components_at_start is enabled. */
-      invoice_metered_components_at_start?: boolean | null;
-      /** Account name for ACH/Wire transfer instructions */
-      ach_account_name?: string | null;
-      /** Second line of bank address for ACH/Wire transfer instructions */
-      ach_bank_address_2?: string | null;
+      /** Default value for whether to align billing cycles to calendar on subscriptions */
+      align_billing_cycles_to_calendar?: boolean | null;
+      /** True if customer updates should be synced to Stripe. */
+      sync_customer_data_to_payment_gateway?: boolean | null;
+      /** Sets the due date on invoices to the number of days after the invoice is sent */
+      days_until_due?: number | null;
+      /** Flag that controls whether or not to invoice/charge the base rate, add ons and other fixed price plan components at the beginning of the billing cycle. */
+      invoice_fixed_components_at_start?: boolean | null;
+      /** Optional url of a custom image to include on invoices. */
+      invoice_logo_url?: string | null;
       /** If using Stripe, this field can be used to configure whether invoices should be finalized immediately when they are created. */
       stripe_immediate_finalization?: boolean | null;
       /** Flag that controls whether to invoice through Octane or through payment provider */
       invoice_via_octane?: boolean | null;
-      /** Time length of the grace period between the end of a billing cycle and invoice generation in days. */
-      invoice_grace_period_length?: number | null;
-      /** Flag that controls whether or not invoices should be sent to customers. */
-      should_send_invoice_to_customers?: boolean | null;
-      /** Flag that controls whether or not to invoice/charge a true up for a billing cycle on the following invoice. Only applies if invoice_fixed_components_at_start is enabled. */
-      invoice_overages?: boolean | null;
+      /** Swift code for ACH/Wire transfer instructions */
+      ach_swift_code?: string | null;
+      /** Flag that controls whether or not to auto-charge the customer based on the invoice. */
+      charges_enabled?: boolean | null;
+      /** Time length unit after which to attempt invoice/payment retry. */
+      retry_frequency_unit?: string | null;
       /** ABA/Routing number for ACH/Wire transfer instructions */
       ach_routing_number?: string | null;
+      /** Flag that controls whether invoices are auto-approved or require manual approval */
+      auto_approve_invoices?: boolean | null;
+      /** Flag that controls whether or not to invoice/charge gauge meters upfront according to their value at start of cycle. Only applies if invoice_fixed_components_at_start is enabled. */
+      invoice_metered_components_at_start?: boolean | null;
+      /** Time length of the grace period between the end of a billing cycle and invoice generation in days. */
+      invoice_grace_period_length?: number | null;
+      /** Time length after which to attempt invoice/payment retry. */
+      retry_frequency_length?: number | null;
+      /** Time length of the grace period between the end of invoice generation and the actual charge. *NOTE*: The specified length is unitless. Unit is designated with the `payment_grace_period_unit` field. */
+      payment_grace_period_length?: number | null;
       /** Account number for ACH/Wire transfer instructions */
       ach_account_number?: string | null;
-      /** The percentage tax rate to apply to invoices. */
-      tax_rate?: number | null;
+      /** Flag that controls whether to do automated taxes via payment provider */
+      tax_via_payment_provider?: boolean | null;
     };
     RevenueResponse: {
       revenue?: number;
@@ -3099,27 +3135,27 @@ export interface components {
       labels?: { [key: string]: string };
     };
     CustomerFeature: {
-      limit?: number;
-      feature_name?: string;
-      enabled?: boolean;
       label_limits?: components['schemas']['CustomerLabelLimit'][];
       quantity?: number;
+      feature_name?: string;
+      enabled?: boolean;
+      limit?: number;
     };
     LineItems: {
-      price?: string;
-      price_int?: number;
-      end_time?: string;
-      id?: string;
       name?: string;
-      metadata?: { [key: string]: string };
+      price_int?: number;
+      quantity?: number;
       start_time?: string;
+      end_time?: string;
       quantity_unit?: string;
       description?: string;
-      quantity?: number;
+      id?: string;
+      price?: string;
+      metadata?: { [key: string]: string };
     };
     RevenueBreakdown: {
-      total_revenue?: number;
       line_items?: components['schemas']['LineItems'][];
+      total_revenue?: number;
     };
     CustomerMetadata: {
       /** Value of property for customer */
@@ -3132,51 +3168,51 @@ export interface components {
       property?: string;
     };
     Invoice: {
-      pdf_url?: string;
-      latest_payment_attempt_at?: string;
-      /** The number of retries done to send the invoice */
-      invoice_retry_attempt?: number;
-      /** Total amount due */
-      amount_due?: number;
-      /** [DEPRECATED] Start time of the cycle in which the invoice was generated */
-      start_time?: string;
-      /** The potentially permanent state this invoice can live in (e.g., ISSUED if the invoice has been issued to the customer) */
-      status?: string;
-      line_items?: components['schemas']['LineItems'][];
+      due_date?: string;
       /** False if invoice has not been sent to the customer */
       is_invoiced?: boolean;
-      /** The date the invoice will be issued to the end customer or forwarded to the payment processor. */
-      issue_date?: string;
-      /** The number of retries done to process the payment */
-      payment_retry_attempt?: number;
-      /** Name of the customer this invoice is for. */
-      customer_name?: string;
-      /** If there is an error processing this invoice, this field contains the error message. */
-      status_error?: string;
-      due_date?: string;
-      /** Amount due before any credits are applied */
-      sub_total?: number;
-      /** External unique 'uuid' identifier for this Invoice. */
-      id?: string;
-      /** False if not paid yet */
-      is_paid?: boolean;
-      latest_invoice_attempt_at?: string;
-      /** Non-empty string if there was an error while sending out invoice */
-      invoicing_error?: string;
-      /** Non-empty string if there was an error while processing payment */
-      payment_error?: string;
-      /** Tax amount applied to subtotal */
-      tax_amount?: number;
       /** [DEPRECATED] End time of the cycle in which the invoice was generated */
       end_time?: string;
-      /** False if not approved */
-      is_approved?: boolean;
-      /** Latest end time of line items covered by the invoice */
-      max_item_end_time?: string;
       /** Earliest start time of line items covered by the invoice */
       min_item_start_time?: string;
+      /** If there is an error processing this invoice, this field contains the error message. */
+      status_error?: string;
+      /** Tax amount applied to subtotal */
+      tax_amount?: number;
+      /** [DEPRECATED] Start time of the cycle in which the invoice was generated */
+      start_time?: string;
+      /** External unique 'uuid' identifier for this Invoice. */
+      id?: string;
+      line_items?: components['schemas']['LineItems'][];
+      /** The number of retries done to send the invoice */
+      invoice_retry_attempt?: number;
+      /** The date the invoice will be issued to the end customer or forwarded to the payment processor. */
+      issue_date?: string;
+      /** Non-empty string if there was an error while processing payment */
+      payment_error?: string;
       /** Any discount credits applied to the invoice */
       discount_credit?: number;
+      latest_invoice_attempt_at?: string;
+      /** False if not paid yet */
+      is_paid?: boolean;
+      /** Amount due before any credits are applied */
+      sub_total?: number;
+      /** False if not approved */
+      is_approved?: boolean;
+      /** The potentially permanent state this invoice can live in (e.g., ISSUED if the invoice has been issued to the customer) */
+      status?: string;
+      /** Latest end time of line items covered by the invoice */
+      max_item_end_time?: string;
+      /** Total amount due */
+      amount_due?: number;
+      /** The number of retries done to process the payment */
+      payment_retry_attempt?: number;
+      /** Non-empty string if there was an error while sending out invoice */
+      invoicing_error?: string;
+      /** Name of the customer this invoice is for. */
+      customer_name?: string;
+      latest_payment_attempt_at?: string;
+      pdf_url?: string;
     };
     CreditTopOffPlan: {
       /** Unique identifier of this top off plan. */
@@ -3191,26 +3227,32 @@ export interface components {
       expiration_length?: number | null;
       /** Time length unit for the default expiration for credits granted in a top off. */
       expiration_unit?: string | null;
+      /** A description that will be used on the invoice line items. */
+      description?: string | null;
     };
     CreateCreditTopOffPlanInputArgs: {
-      /** Price for the grant, in lowest denomination (i.e cents). */
-      price: number;
-      /** Amount of credits that are granted in a single top off. */
-      grant_amount: number;
       /** Time length unit for the default expiration for credits granted in a top off. */
       expiration_unit?: string;
+      /** Amount of credits that are granted in a single top off. */
+      grant_amount: number;
+      /** A description that will be used on the invoice line items. */
+      description?: string;
+      /** Price for the grant, in lowest denomination (i.e cents). */
+      price: number;
       /** Time length of the default expiration for credits granted in a top off. */
       expiration_length?: number;
       /** The threshold in amount of credits at which the balance will be topped off. */
       trigger_amount: number;
     };
     UpdateCreditTopOffPlanInputArgs: {
-      /** Price for the grant, in lowest denomination (i.e cents). */
-      price?: number;
-      /** Amount of credits that are granted in a single top off. */
-      grant_amount?: number;
       /** Time length unit for the default expiration for credits granted in a top off. */
       expiration_unit?: string;
+      /** Amount of credits that are granted in a single top off. */
+      grant_amount?: number;
+      /** A description that will be used on the invoice line items. */
+      description?: string;
+      /** Price for the grant, in lowest denomination (i.e cents). */
+      price?: number;
       /** Time length of the default expiration for credits granted in a top off. */
       expiration_length?: number;
       /** The threshold in amount of credits at which the balance will be topped off. */
@@ -3221,40 +3263,40 @@ export interface components {
       accounting_customer_id?: string;
     };
     CustomerAvalaraSettings: {
+      /** True if Avalara integration should be enabled for this customer, False otherwise. */
+      enable_integration?: boolean;
       /** Tax exemption number specific to this customer */
       exemption_number?: string;
       /** Entity code describing this customer. */
       entity_use_code?: string;
-      /** True if Avalara integration should be enabled for this customer, False otherwise. */
-      enable_integration?: boolean;
     };
     UpdateCustomerAvalaraSettingsArgs: {
+      /** True if Avalara integration should be enabled for this customer, False otherwise. */
+      enable_integration?: boolean;
       /** Tax exemption number specific to this customer */
       exemption_number?: string;
       /** Entity code describing this customer. */
       entity_use_code?: string;
-      /** True if Avalara integration should be enabled for this customer, False otherwise. */
-      enable_integration?: boolean;
     };
     ValidateAddressResp: {
+      /** Set if 'sucess' is True. Geospatial latitude measurement, in Decimal Degrees (string). */
+      longitude?: string;
       /** True if validation was successful, False address is invalid. */
       success?: boolean;
-      /** Set if 'success' is True. Geospatial latitude measurement, in Decimal Degrees (string). */
-      latitude?: string;
       /** Set if 'success' is True. The resolution quality of the geospatial coordinates. */
       resolution_quality?: string;
       /** Set if 'success' is False. Contains the details of why the address is invalid. */
       invalid_address_error?: string;
-      /** Set if 'sucess' is True. Geospatial latitude measurement, in Decimal Degrees (string). */
-      longitude?: string;
+      /** Set if 'success' is True. Geospatial latitude measurement, in Decimal Degrees (string). */
+      latitude?: string;
     };
     PriceTier: {
+      /** Cap of the tier, meaning that any subsequent usage will be bucketed into the following tier. If cap is undefined, it is effectively treated as Infinity. */
+      cap?: number;
       /** The price (in lowest currency denomination by which to charge, given that the usage is within the cap range. */
       price: number;
       /** The line item description to use if usage falls in this tier. */
       description?: string;
-      /** Cap of the tier, meaning that any subsequent usage will be bucketed into the following tier. If cap is undefined, it is effectively treated as Infinity. */
-      cap?: number;
     };
     PriceScheme: {
       display_name?: string | null;
@@ -3399,95 +3441,95 @@ export interface components {
       /** ISO-8601 formatted timestamp that defines when the subscription will expire. */
       expired_at?: string | null;
     };
-    FeatureInputArgs: {
-      description?: string;
-      display_name?: string;
-      name: string;
+    TrialInputArgs: {
+      time_length?: number;
+      time_unit_name?: string;
+      credit?: number;
     };
-    LimitInputArgs: {
-      feature: components['schemas']['FeatureInputArgs'];
-      limit?: number;
+    FeatureInputArgs: {
+      name: string;
+      display_name?: string;
+      description?: string;
     };
     DiscountInputArgs: {
-      amount?: number;
+      /** Length, in billing cycles, that this discount will be active. */
+      billing_cycle_duration?: number;
+      /** For ADD_ON scoped discounts: the name of the add on that the discount covers. */
+      add_on_name?: string;
+      discount_type?: 'FLAT' | 'PERCENT';
       /** For METERED_COMPONENT scoped discounts: the UUID of the metered component that the discount covers. */
       metered_component_uuid?: string;
       /** For METERED_COMPONENT scoped discounts: Dictionary of labels (key: value) that the discount covers. The entire set of labels must be provided. */
       labels?: { [key: string]: string };
       /** Offset, in number of billing cycles, for when this discount will apply. If set to 0, the discount will start applying from the current billing cycle. If set to 1, the discount will start applying from the next billing cycle, etc. For scheduled subscriptions, the offset starts from the initial billing cycle. */
       billing_cycle_start_offset?: number;
-      /** Length, in billing cycles, that this discount will be active. */
-      billing_cycle_duration?: number;
-      /** For ADD_ON scoped discounts: the name of the add on that the discount covers. */
-      add_on_name?: string;
+      amount?: number;
       /** The scope that this discount covers. One of 'INVOICE_TOTAL', 'ADD_ON', 'METERED_COMPONENT'. */
       scope?: 'INVOICE_TOTAL' | 'ADD_ON' | 'METERED_COMPONENT';
-      discount_type?: 'FLAT' | 'PERCENT';
     };
-    TrialInputArgs: {
-      time_length?: number;
-      credit?: number;
-      time_unit_name?: string;
+    LimitInputArgs: {
+      feature: components['schemas']['FeatureInputArgs'];
+      limit?: number;
     };
     SubscriptionAddOnInput: {
-      /** Override for the add-on price on this subscription. */
-      price?: number;
       name: string;
       quantity?: number;
+      /** Override for the add-on price on this subscription. */
+      price?: number;
     };
     CreateSubscriptionArgs: {
-      price_plan_name?: string;
-      effective_at?: string;
-      price_plan_tag?: string;
-      features_override?: components['schemas']['FeatureInputArgs'][];
-      limits_override?: components['schemas']['LimitInputArgs'][];
-      customer_id?: number;
       price_plan_id?: number;
-      discounts?: components['schemas']['DiscountInputArgs'][];
-      coupon_override_id?: number;
+      vendor_id?: number;
+      trial_override?: components['schemas']['TrialInputArgs'];
+      features_override?: components['schemas']['FeatureInputArgs'][];
       /** DEPRECATED - use discounts field */
       discount_override?: components['schemas']['DiscountInputArgs'];
-      trial_override?: components['schemas']['TrialInputArgs'];
-      vendor_id?: number;
-      add_ons?: components['schemas']['SubscriptionAddOnInput'][];
+      customer_id?: number;
+      coupon_override_id?: number;
       align_to_calendar?: boolean;
       coupon_override_name?: string;
+      discounts?: components['schemas']['DiscountInputArgs'][];
+      limits_override?: components['schemas']['LimitInputArgs'][];
+      effective_at?: string;
+      price_plan_tag?: string;
+      add_ons?: components['schemas']['SubscriptionAddOnInput'][];
+      price_plan_name?: string;
     };
     UpdateSubscriptionArgs: {
-      price_plan_name?: string;
-      effective_at?: string;
-      /** Boolean that indicates whether to update the subscription at the end of the billing cycle. If 'true' and either of `effective_at` or `at_cycle_start` are set, will return an error. */
-      at_cycle_end?: boolean;
+      price_plan_id?: number;
+      vendor_id?: number;
+      trial_override?: components['schemas']['TrialInputArgs'] | null;
+      features_override?: components['schemas']['FeatureInputArgs'][] | null;
+      /** DEPRECATED - use discounts field */
+      discount_override?: components['schemas']['DiscountInputArgs'] | null;
+      customer_id?: number;
+      coupon_override_id?: number;
+      align_to_calendar?: boolean;
       /** Boolean that indicates whether to update the subscription at the start of the billing cycle. If 'true' and either of `effective_at` or `at_cycle_end` are set, will return an error. */
       at_cycle_start?: boolean;
-      price_plan_tag?: string;
-      features_override?: components['schemas']['FeatureInputArgs'][] | null;
-      limits_override?: components['schemas']['LimitInputArgs'][] | null;
-      customer_id?: number;
-      price_plan_id?: number;
-      discounts?: components['schemas']['DiscountInputArgs'][];
-      coupon_override_id?: number;
-      /** DEPRECATED - use discounts field */
-      discount_override?: components['schemas']['DiscountInputArgs'] | null;
-      trial_override?: components['schemas']['TrialInputArgs'] | null;
-      vendor_id?: number;
-      add_ons?: components['schemas']['SubscriptionAddOnInput'][] | null;
-      align_to_calendar?: boolean;
       coupon_override_name?: string;
+      discounts?: components['schemas']['DiscountInputArgs'][];
+      limits_override?: components['schemas']['LimitInputArgs'][] | null;
+      effective_at?: string;
+      price_plan_tag?: string;
+      add_ons?: components['schemas']['SubscriptionAddOnInput'][] | null;
+      price_plan_name?: string;
+      /** Boolean that indicates whether to update the subscription at the end of the billing cycle. If 'true' and either of `effective_at` or `at_cycle_start` are set, will return an error. */
+      at_cycle_end?: boolean;
     };
     DeleteSubscriptionArgs: {
-      /** Boolean that indicates whether to expire the subscription at the end of thebilling cycle. If 'true' and `expire_at` is set, will return an error. */
-      at_cycle_end?: boolean;
+      expire_at?: string;
       vendor_id?: number;
       customer_id?: number;
-      expire_at?: string;
+      /** Boolean that indicates whether to expire the subscription at the end of thebilling cycle. If 'true' and `expire_at` is set, will return an error. */
+      at_cycle_end?: boolean;
     };
     UpdateSubscriptionInPlaceArgs: {
+      /** DEPRECATED - use discounts field */
+      discount_override?: components['schemas']['DiscountInputArgs'] | null;
       discounts?: components['schemas']['DiscountInputArgs'][];
       add_ons?: components['schemas']['SubscriptionAddOnInput'][] | null;
       coupon_override_name?: string;
-      /** DEPRECATED - use discounts field */
-      discount_override?: components['schemas']['DiscountInputArgs'] | null;
     };
     BillingCycleDate: {
       cycle_end: string;
@@ -3519,14 +3561,14 @@ export interface components {
       discounted_fixed_price?: number;
     };
     SubscriptionAddOnItem: {
+      /** Quantity represents how many of this add on you want to attach to the subscription. Can be positive forincreasing the number of this add on or negative for decreasing. */
+      quantity?: number;
+      feature_name?: string;
+      /** Boolean that indicates whether to update the subscription add on at the start of the billing cycle. If 'true' and either of `effective_at` or `at_cycle_end` are set, will return an error. */
+      at_cycle_start?: boolean;
       effective_at?: string;
       /** Boolean that indicates whether to update the subscription add on at the end of the billing cycle. If 'true' and either of `effective_at` or `at_cycle_start` are set, will return an error. */
       at_cycle_end?: boolean;
-      /** Boolean that indicates whether to update the subscription add on at the start of the billing cycle. If 'true' and either of `effective_at` or `at_cycle_end` are set, will return an error. */
-      at_cycle_start?: boolean;
-      feature_name?: string;
-      /** Quantity represents how many of this add on you want to attach to the subscription. Can be positive forincreasing the number of this add on or negative for decreasing. */
-      quantity?: number;
     };
     DeleteDiscountInputArgs: {
       /** External UUID representing the discount to be deleted. */
@@ -3534,50 +3576,50 @@ export interface components {
     };
     PastInvoice: {
       issue_date?: string;
+      due_date?: string;
+      status_description?: string;
+      amount_due?: number;
       export_url?: string;
-      customer_name?: string;
       /** External unique 'uuid' identifier for this Invoice. */
       id?: string;
-      due_date?: string;
-      amount_due?: number;
+      customer_name?: string;
       status?: string;
-      status_description?: string;
     };
     PastInvoices: {
-      /** The number of items to fetch. Defaults to 10. */
-      limit?: number;
-      sort_direction?: string;
-      sort_column?: string;
-      invoices?: components['schemas']['PastInvoice'][];
       /** The sort column offset to start at when paging forwards */
       forward_sort_offset?: string;
+      sort_direction?: string;
+      sort_column?: string;
       /** The unique offset to start at when paging forwards */
       forward_secondary_sort_offset?: string;
+      invoices?: components['schemas']['PastInvoice'][];
+      /** The number of items to fetch. Defaults to 10. */
+      limit?: number;
     };
     CreateRetryArgs: { [key: string]: unknown };
     Retry: {
       success?: boolean;
     };
     PriceInputArgs: {
+      cap?: number;
       price?: number;
       description?: string;
-      cap?: number;
     };
     PriceSchemeInputArgs: {
-      /** Array of (key, value) meter labels to price on & the price tiers that should be used against those labels */
-      price_list?: { [key: string]: unknown }[];
       /** Array of price tiers, each of which consists of `price` and `cap` key:value pairs */
       prices?: components['schemas']['PriceInputArgs'][];
       /** Size of the unit batch to use for the prices. Can only be set if scheme_type='FLAT' or 'TIERED'. E.g. To charge $10 per 100 API Requests, set batch_size to 100. */
       batch_size?: number;
       /** The name of the unit used for this metered component (e.g., gigabyte) */
       unit_name?: string;
+      /** Array of (key, value) meter labels to price on & the price tiers that should be used against those labels */
+      price_list?: { [key: string]: unknown }[];
       /** The % increase/decrease in price after the minimum charge is reached (e.g., 25.5 -> 25.5% increase). */
       post_minimum_charge_percentage_change?: number;
-      /** One of 'FLAT', 'TIERED', or 'STAIRSTEP' */
-      scheme_type: string;
       /** The time unit for the metered component (e.g., month or hour) */
       time_unit_name?: string;
+      /** One of 'FLAT', 'TIERED', or 'STAIRSTEP' */
+      scheme_type: string;
     };
     MeteredComponentLabelLimitInputArgs: {
       /** Numeric limit to set on customer usage for the meter with the given labels. */
@@ -3586,95 +3628,95 @@ export interface components {
       labels: { [key: string]: string };
     };
     MeteredComponentInputArgs: {
-      /** Numeric limit to set on customer usage for the meter. */
-      limit?: number;
-      meter_id?: number;
+      price_scheme?: components['schemas']['PriceSchemeInputArgs'];
+      label_limits?: components['schemas']['MeteredComponentLabelLimitInputArgs'][];
+      /** Name to be used on invoice. */
+      display_name?: string;
+      /** Codename of the meter. */
+      meter_name?: string;
       /** Minimum charge frequency (as a multiple of the price plan period) for the metered component */
       minimum_charge_frequency?: number | null;
       id?: number;
-      price_scheme?: components['schemas']['PriceSchemeInputArgs'];
-      /** Codename of the meter. */
-      meter_name?: string;
-      /** Name to be used on invoice. */
-      display_name?: string;
-      label_limits?: components['schemas']['MeteredComponentLabelLimitInputArgs'][];
       /** Minimum charge for the metered component */
       minimum_charge?: number | null;
+      meter_id?: number;
+      /** Numeric limit to set on customer usage for the meter. */
+      limit?: number;
     };
     AddOnInputArgs: {
-      price?: number;
-      limit?: number;
+      feature: components['schemas']['FeatureInputArgs'];
       quantity_enabled?: boolean;
       /** Whether this add on can only be used & charged once. */
       single_use?: boolean;
       /** This field indicates whether or not we should cut an invoice immediately upon attaching this add on to a price plan. */
       immediately_charge?: boolean;
-      feature: components['schemas']['FeatureInputArgs'];
+      price?: number;
+      limit?: number;
     };
     CreatePricePlanArgs: {
-      metered_components?: components['schemas']['MeteredComponentInputArgs'][];
-      tags?: string[];
-      base_price?: number;
-      trial?: components['schemas']['TrialInputArgs'];
-      /** The frequency (as a an integer multiple of the period) at which to charge the minimum charge. */
-      minimum_charge_frequency?: number | null;
-      features?: components['schemas']['FeatureInputArgs'][];
-      limits?: components['schemas']['LimitInputArgs'][];
+      name?: string;
       /** The frequency (as a an integer multiple of the period) at which to charge the base price. */
       base_price_frequency?: number;
-      name?: string;
-      period?: string;
-      display_name?: string;
       vendor_id?: number;
+      period?: string;
+      metered_components?: components['schemas']['MeteredComponentInputArgs'][];
+      tags?: string[];
+      display_name?: string;
       /** Custom invoice description for the base price line item. */
       base_price_description?: string | null;
+      limits?: components['schemas']['LimitInputArgs'][];
+      /** The frequency (as a an integer multiple of the period) at which to charge the minimum charge. */
+      minimum_charge_frequency?: number | null;
       description?: string;
-      add_ons?: components['schemas']['AddOnInputArgs'][];
+      features?: components['schemas']['FeatureInputArgs'][];
+      trial?: components['schemas']['TrialInputArgs'];
       /** Minimum amount (in cents) to charge every price plan period. */
       minimum_charge?: number | null;
+      base_price?: number;
+      add_ons?: components['schemas']['AddOnInputArgs'][];
     };
     ListPricePlans: {
-      /** The number of items to fetch. Defaults to 10. */
-      limit?: number;
-      sort_direction?: string;
-      sort_column?: string;
       /** The sort column offset to start at when paging forwards */
       forward_sort_offset?: string;
-      price_plans?: components['schemas']['PricePlan'][];
+      sort_direction?: string;
+      sort_column?: string;
       /** The unique offset to start at when paging forwards */
       forward_secondary_sort_offset?: string;
+      price_plans?: components['schemas']['PricePlan'][];
+      /** The number of items to fetch. Defaults to 10. */
+      limit?: number;
     };
     UpdatePricePlanArgs: {
-      metered_components?: components['schemas']['MeteredComponentInputArgs'][];
-      tags?: string[];
-      base_price?: number;
-      trial?: components['schemas']['TrialInputArgs'];
-      /** The frequency (as a an integer multiple of the period) at which to charge the minimum charge. */
-      minimum_charge_frequency?: number | null;
-      features?: components['schemas']['FeatureInputArgs'][];
-      limits?: components['schemas']['LimitInputArgs'][];
+      name?: string;
       /** The frequency (as a an integer multiple of the period) at which to charge the base price. */
       base_price_frequency?: number;
-      name?: string;
-      period?: string;
-      display_name?: string;
       vendor_id?: number;
+      period?: string;
+      metered_components?: components['schemas']['MeteredComponentInputArgs'][];
+      tags?: string[];
+      display_name?: string;
       /** Custom invoice description for the base price line item. */
       base_price_description?: string | null;
+      limits?: components['schemas']['LimitInputArgs'][];
+      /** The frequency (as a an integer multiple of the period) at which to charge the minimum charge. */
+      minimum_charge_frequency?: number | null;
       description?: string;
-      add_ons?: components['schemas']['AddOnInputArgs'][];
+      features?: components['schemas']['FeatureInputArgs'][];
+      trial?: components['schemas']['TrialInputArgs'];
       /** Minimum amount (in cents) to charge every price plan period. */
       minimum_charge?: number | null;
+      base_price?: number;
+      add_ons?: components['schemas']['AddOnInputArgs'][];
     };
     UpdatePricePlanInPlaceArgs: {
       metered_components?: components['schemas']['MeteredComponentInputArgs'][];
-      features?: components['schemas']['FeatureInputArgs'][];
       display_name?: string;
       /** Custom invoice description for the base price line item. */
       base_price_description?: string | null;
-      description?: string;
-      add_ons?: components['schemas']['AddOnInputArgs'][];
       limits?: components['schemas']['LimitInputArgs'][];
+      description?: string;
+      features?: components['schemas']['FeatureInputArgs'][];
+      add_ons?: components['schemas']['AddOnInputArgs'][];
     };
     SelfServePricePlansInputArgs: {
       price_plan_uuids?: string[];
@@ -3708,134 +3750,134 @@ export interface components {
       auth_token?: string;
     };
     CreateBillingSettingsInputArgs: {
-      /** Flag that controls whether to do automated taxes via payment provider */
-      tax_via_payment_provider?: boolean;
-      /** Flag that controls the number of retry attempts for invoicing/payments. */
-      retry_attempts?: number;
-      /** Time length unit of the grace period between the end of invoice generation and actual charge. One of `minute`, `hour`, `day`. */
-      payment_grace_period_unit?: string;
-      /** Optional url of a custom image to include on invoices. */
-      invoice_logo_url?: string | null;
       customer_invoice_detail_level?: string;
-      /** If using stripe, this field can be used to configure whether invoices should be auto advanced for collection */
-      stripe_auto_advance?: boolean;
-      /** Flag that controls whether or not to auto-charge the customer based on the invoice. */
-      charges_enabled?: boolean;
-      /** Time length of the grace period between the end of invoice generation and the actual charge. *NOTE*: The specified length is unitless. Unit is designated with the `payment_grace_period_unit` field. */
-      payment_grace_period_length?: number;
-      /** Sets the due date on invoices to the number of days after the invoice is sent */
-      days_until_due?: number | null;
-      /** Default value for whether to align billing cycles to calendar on subscriptions */
-      align_billing_cycles_to_calendar?: boolean;
-      /** Flag that controls whether invoices are auto-approved or require manual approval */
-      auto_approve_invoices?: boolean;
-      /** True if customer updates should be synced to Stripe. */
-      sync_customer_data_to_payment_gateway?: boolean | null;
+      /** The percentage tax rate to apply to invoices. */
+      tax_rate?: number | null;
+      /** Flag that controls whether or not to invoice/charge a true up for a billing cycle on the following invoice. Only applies if invoice_fixed_components_at_start is enabled. */
+      invoice_overages?: boolean;
+      /** Optional description attached to the invoice */
+      invoice_memo?: string | null;
       /** Bank name for ACH/Wire transfer instructions */
       ach_bank_name?: string | null;
-      /** Swift code for ACH/Wire transfer instructions */
-      ach_swift_code?: string | null;
+      /** Account name for ACH/Wire transfer instructions */
+      ach_account_name?: string | null;
+      /** If using stripe, this field can be used to configure whether invoices should be auto advanced for collection */
+      stripe_auto_advance?: boolean;
+      /** Flag that controls the number of retry attempts for invoicing/payments. */
+      retry_attempts?: number;
+      /** Second line of bank address for ACH/Wire transfer instructions */
+      ach_bank_address_2?: string | null;
       /** Flag determining whether ACH/Wire instructions should be included on invoices. */
       include_ach_instructions?: boolean | null;
       /** Time length unit of the grace period between the end of a billing cycle and invoice generation. Must be `day`. */
       invoice_grace_period_unit?: 'day';
-      /** Time length after which to attempt invoice/payment retry. */
-      retry_frequency_length?: number;
-      /** Time length unit after which to attempt invoice/payment retry. */
-      retry_frequency_unit?: string;
-      /** Flag that controls whether or not to invoice/charge the base rate, add ons and other fixed price plan components at the beginning of the billing cycle. */
-      invoice_fixed_components_at_start?: boolean;
-      /** Optional description attached to the invoice */
-      invoice_memo?: string | null;
+      /** Time length unit of the grace period between the end of invoice generation and actual charge. One of `minute`, `hour`, `day`. */
+      payment_grace_period_unit?: string;
+      /** Flag that controls whether or not invoices should be sent to customers. */
+      should_send_invoice_to_customers?: boolean;
       /** First line of bank address for ACH/Wire transfer instructions */
       ach_bank_address_1?: string | null;
-      /** Flag that controls whether or not to invoice/charge gauge meters upfront according to their value at start of cycle. Only applies if invoice_fixed_components_at_start is enabled. */
-      invoice_metered_components_at_start?: boolean;
-      /** Account name for ACH/Wire transfer instructions */
-      ach_account_name?: string | null;
-      /** Second line of bank address for ACH/Wire transfer instructions */
-      ach_bank_address_2?: string | null;
+      /** Default value for whether to align billing cycles to calendar on subscriptions */
+      align_billing_cycles_to_calendar?: boolean;
+      /** True if customer updates should be synced to Stripe. */
+      sync_customer_data_to_payment_gateway?: boolean | null;
+      /** Sets the due date on invoices to the number of days after the invoice is sent */
+      days_until_due?: number | null;
+      /** Flag that controls whether or not to invoice/charge the base rate, add ons and other fixed price plan components at the beginning of the billing cycle. */
+      invoice_fixed_components_at_start?: boolean;
+      /** Optional url of a custom image to include on invoices. */
+      invoice_logo_url?: string | null;
       /** If using Stripe, this field can be used to configure whether invoices should be finalized immediately when they are created. */
       stripe_immediate_finalization?: boolean | null;
       /** Flag that controls whether to invoice through Octane or through payment provider */
       invoice_via_octane?: boolean;
-      /** Time length of the grace period between the end of a billing cycle and invoice generation in days. */
-      invoice_grace_period_length?: number;
-      /** Flag that controls whether or not invoices should be sent to customers. */
-      should_send_invoice_to_customers?: boolean;
-      /** Flag that controls whether or not to invoice/charge a true up for a billing cycle on the following invoice. Only applies if invoice_fixed_components_at_start is enabled. */
-      invoice_overages?: boolean;
+      /** Swift code for ACH/Wire transfer instructions */
+      ach_swift_code?: string | null;
+      /** Flag that controls whether or not to auto-charge the customer based on the invoice. */
+      charges_enabled?: boolean;
+      /** Time length unit after which to attempt invoice/payment retry. */
+      retry_frequency_unit?: string;
       /** ABA/Routing number for ACH/Wire transfer instructions */
       ach_routing_number?: string | null;
+      /** Flag that controls whether invoices are auto-approved or require manual approval */
+      auto_approve_invoices?: boolean;
+      /** Flag that controls whether or not to invoice/charge gauge meters upfront according to their value at start of cycle. Only applies if invoice_fixed_components_at_start is enabled. */
+      invoice_metered_components_at_start?: boolean;
+      /** Time length of the grace period between the end of a billing cycle and invoice generation in days. */
+      invoice_grace_period_length?: number;
+      /** Time length after which to attempt invoice/payment retry. */
+      retry_frequency_length?: number;
+      /** Time length of the grace period between the end of invoice generation and the actual charge. *NOTE*: The specified length is unitless. Unit is designated with the `payment_grace_period_unit` field. */
+      payment_grace_period_length?: number;
       /** Account number for ACH/Wire transfer instructions */
       ach_account_number?: string | null;
-      /** The percentage tax rate to apply to invoices. */
-      tax_rate?: number | null;
+      /** Flag that controls whether to do automated taxes via payment provider */
+      tax_via_payment_provider?: boolean;
     };
     UpdateBillingSettingsInputArgs: {
-      /** Flag that controls whether to do automated taxes via payment provider */
-      tax_via_payment_provider?: boolean;
-      /** Flag that controls the number of retry attempts for invoicing/payments. */
-      retry_attempts?: number;
-      /** Time length unit of the grace period between the end of invoice generation and actual charge. One of `minute`, `hour`, `day`. */
-      payment_grace_period_unit?: string;
-      /** Optional url of a custom image to include on invoices. */
-      invoice_logo_url?: string | null;
       customer_invoice_detail_level?: string;
-      /** If using stripe, this field can be used to configure whether invoices should be auto advanced for collection */
-      stripe_auto_advance?: boolean;
-      /** Flag that controls whether or not to auto-charge the customer based on the invoice. */
-      charges_enabled?: boolean;
-      /** Time length of the grace period between the end of invoice generation and the actual charge. *NOTE*: The specified length is unitless. Unit is designated with the `payment_grace_period_unit` field. */
-      payment_grace_period_length?: number;
-      /** Sets the due date on invoices to the number of days after the invoice is sent */
-      days_until_due?: number | null;
-      /** Default value for whether to align billing cycles to calendar on subscriptions */
-      align_billing_cycles_to_calendar?: boolean;
-      /** Flag that controls whether invoices are auto-approved or require manual approval */
-      auto_approve_invoices?: boolean;
-      /** True if customer updates should be synced to Stripe. */
-      sync_customer_data_to_payment_gateway?: boolean | null;
+      /** The percentage tax rate to apply to invoices. */
+      tax_rate?: number | null;
+      /** Flag that controls whether or not to invoice/charge a true up for a billing cycle on the following invoice. Only applies if invoice_fixed_components_at_start is enabled. */
+      invoice_overages?: boolean;
+      /** Optional description attached to the invoice */
+      invoice_memo?: string | null;
       /** Bank name for ACH/Wire transfer instructions */
       ach_bank_name?: string | null;
-      /** Swift code for ACH/Wire transfer instructions */
-      ach_swift_code?: string | null;
+      /** Account name for ACH/Wire transfer instructions */
+      ach_account_name?: string | null;
+      /** If using stripe, this field can be used to configure whether invoices should be auto advanced for collection */
+      stripe_auto_advance?: boolean;
+      /** Flag that controls the number of retry attempts for invoicing/payments. */
+      retry_attempts?: number;
+      /** Second line of bank address for ACH/Wire transfer instructions */
+      ach_bank_address_2?: string | null;
       /** Flag determining whether ACH/Wire instructions should be included on invoices. */
       include_ach_instructions?: boolean | null;
       /** Time length unit of the grace period between the end of a billing cycle and invoice generation. Must be `day`. */
       invoice_grace_period_unit?: 'day';
-      /** Time length after which to attempt invoice/payment retry. */
-      retry_frequency_length?: number;
-      /** Time length unit after which to attempt invoice/payment retry. */
-      retry_frequency_unit?: string;
-      /** Flag that controls whether or not to invoice/charge the base rate, add ons and other fixed price plan components at the beginning of the billing cycle. */
-      invoice_fixed_components_at_start?: boolean;
-      /** Optional description attached to the invoice */
-      invoice_memo?: string | null;
+      /** Time length unit of the grace period between the end of invoice generation and actual charge. One of `minute`, `hour`, `day`. */
+      payment_grace_period_unit?: string;
+      /** Flag that controls whether or not invoices should be sent to customers. */
+      should_send_invoice_to_customers?: boolean;
       /** First line of bank address for ACH/Wire transfer instructions */
       ach_bank_address_1?: string | null;
-      /** Flag that controls whether or not to invoice/charge gauge meters upfront according to their value at start of cycle. Only applies if invoice_fixed_components_at_start is enabled. */
-      invoice_metered_components_at_start?: boolean;
-      /** Account name for ACH/Wire transfer instructions */
-      ach_account_name?: string | null;
-      /** Second line of bank address for ACH/Wire transfer instructions */
-      ach_bank_address_2?: string | null;
+      /** Default value for whether to align billing cycles to calendar on subscriptions */
+      align_billing_cycles_to_calendar?: boolean;
+      /** True if customer updates should be synced to Stripe. */
+      sync_customer_data_to_payment_gateway?: boolean | null;
+      /** Sets the due date on invoices to the number of days after the invoice is sent */
+      days_until_due?: number | null;
+      /** Flag that controls whether or not to invoice/charge the base rate, add ons and other fixed price plan components at the beginning of the billing cycle. */
+      invoice_fixed_components_at_start?: boolean;
+      /** Optional url of a custom image to include on invoices. */
+      invoice_logo_url?: string | null;
       /** If using Stripe, this field can be used to configure whether invoices should be finalized immediately when they are created. */
       stripe_immediate_finalization?: boolean | null;
       /** Flag that controls whether to invoice through Octane or through payment provider */
       invoice_via_octane?: boolean;
-      /** Time length of the grace period between the end of a billing cycle and invoice generation in days. */
-      invoice_grace_period_length?: number;
-      /** Flag that controls whether or not invoices should be sent to customers. */
-      should_send_invoice_to_customers?: boolean;
-      /** Flag that controls whether or not to invoice/charge a true up for a billing cycle on the following invoice. Only applies if invoice_fixed_components_at_start is enabled. */
-      invoice_overages?: boolean;
+      /** Swift code for ACH/Wire transfer instructions */
+      ach_swift_code?: string | null;
+      /** Flag that controls whether or not to auto-charge the customer based on the invoice. */
+      charges_enabled?: boolean;
+      /** Time length unit after which to attempt invoice/payment retry. */
+      retry_frequency_unit?: string;
       /** ABA/Routing number for ACH/Wire transfer instructions */
       ach_routing_number?: string | null;
+      /** Flag that controls whether invoices are auto-approved or require manual approval */
+      auto_approve_invoices?: boolean;
+      /** Flag that controls whether or not to invoice/charge gauge meters upfront according to their value at start of cycle. Only applies if invoice_fixed_components_at_start is enabled. */
+      invoice_metered_components_at_start?: boolean;
+      /** Time length of the grace period between the end of a billing cycle and invoice generation in days. */
+      invoice_grace_period_length?: number;
+      /** Time length after which to attempt invoice/payment retry. */
+      retry_frequency_length?: number;
+      /** Time length of the grace period between the end of invoice generation and the actual charge. *NOTE*: The specified length is unitless. Unit is designated with the `payment_grace_period_unit` field. */
+      payment_grace_period_length?: number;
       /** Account number for ACH/Wire transfer instructions */
       ach_account_number?: string | null;
-      /** The percentage tax rate to apply to invoices. */
-      tax_rate?: number | null;
+      /** Flag that controls whether to do automated taxes via payment provider */
+      tax_via_payment_provider?: boolean;
     };
     Customer1: {
       /** Unique name identifier of a customer */
@@ -3883,19 +3925,19 @@ export interface components {
       discount_amount: number;
     };
     ApplyCouponInputArgs: {
+      name?: string;
+      vendor_id?: number;
+      customer_id?: number;
       code?: string;
       customer_name?: string;
-      name?: string;
-      customer_id?: number;
-      vendor_id?: number;
     };
     CreateRefundArgs: {
       /** Invoice that the refund should be against */
-      invoice_id?: number;
+      invoice_uuid?: string;
       /** Amount to be refunded */
       amount?: number;
       /** Invoice that the refund should be against */
-      invoice_uuid?: string;
+      invoice_id?: number;
     };
     Refund: {
       success?: boolean;
@@ -3921,75 +3963,75 @@ export interface components {
       url?: string;
     };
     CustomerPortalVendor: {
-      /** Full contact info for the Vendor */
-      contact_info?: components['schemas']['ContactInfo'];
       /** Unique name identifier of a Vendor */
       name?: string;
-      /** Vendor's current payment gateway. */
-      payment_gateway?: string;
       /** Display name for the Vendor */
       display_name?: string;
+      /** Full contact info for the Vendor */
+      contact_info?: components['schemas']['ContactInfo'];
+      /** Vendor's current payment gateway. */
+      payment_gateway?: string;
       /** Currency preference of the Vendor. */
       currency?: string;
     };
     CustomerPortalInvoiceStatus: {
-      /** Time the invoice status was last updated. */
-      updated_at?: string;
-      error?: string;
       update_source?: string;
-      /** The current processing state for this invoice. */
-      status?: string;
-      /** The current upcoming action associated with this invoice status, if any. */
-      action?: string;
       /** The timestamp that the action will be performed at. */
       pending_action_time?: string;
+      /** The current upcoming action associated with this invoice status, if any. */
+      action?: string;
+      error?: string;
       /** Creation time of this invoice status. */
       created_at?: string;
+      /** Time the invoice status was last updated. */
+      updated_at?: string;
+      /** The current processing state for this invoice. */
+      status?: string;
     };
     CustomerPortalInvoice: {
       /** The date the invoice will be issued to the end customer or forwarded to the payment processor. */
       issue_date?: string;
-      /** Url pointing to the pdf of this invoice. */
-      pdf_url?: string;
-      /** [DEPRECATED] End time of the cycle in which the invoice was generated */
-      end_time?: string;
-      id?: string;
       due_date?: string;
-      /** False if not paid yet */
-      is_paid?: boolean;
       /** Total amount due */
       amount_due?: number;
-      /** [DEPRECATED] Start time of the cycle in which the invoice was generated */
-      start_time?: string;
-      /** Latest end time of line items covered by the invoice */
-      max_item_end_time?: string;
       /** Tax amount applied to subtotal */
       tax_amount?: number;
-      /** Information related to the current status of this invoice. */
-      status?: components['schemas']['CustomerPortalInvoiceStatus'];
+      /** [DEPRECATED] Start time of the cycle in which the invoice was generated */
+      start_time?: string;
       /** Any discount credits applied to the invoice */
       discount_credit?: number;
-      /** Earliest start time of line items covered by the invoice */
-      min_item_start_time?: string;
-      line_items?: components['schemas']['LineItems'][];
+      /** [DEPRECATED] End time of the cycle in which the invoice was generated */
+      end_time?: string;
+      /** False if not paid yet */
+      is_paid?: boolean;
       /** Amount due before any credits are applied */
       sub_total?: number;
+      id?: string;
+      line_items?: components['schemas']['LineItems'][];
+      /** Earliest start time of line items covered by the invoice */
+      min_item_start_time?: string;
+      /** Information related to the current status of this invoice. */
+      status?: components['schemas']['CustomerPortalInvoiceStatus'];
+      /** Latest end time of line items covered by the invoice */
+      max_item_end_time?: string;
+      /** Url pointing to the pdf of this invoice. */
+      pdf_url?: string;
     };
     CustomerPortalActiveSubscription: {
-      /** Customer's current active biling cycle. */
-      billing_cycle: components['schemas']['BillingCycleDate'];
-      /** The date that the customer will be invoiced for their current billing cycle. */
-      invoicing_date?: string;
-      /** Customer's current active subscription. Includes the price plan and overrides they are subscribed to. */
-      subscription?: components['schemas']['Subscription'];
       /** The total fixed price with all discounts applied. */
       discounted_fixed_price?: number;
+      /** Customer's current active subscription. Includes the price plan and overrides they are subscribed to. */
+      subscription?: components['schemas']['Subscription'];
+      /** The date that the customer will be invoiced for their current billing cycle. */
+      invoicing_date?: string;
       /** The total fixed price the customer will be charged for this billing cycle. Includes the base price and any add ons. */
       total_fixed_price?: number;
+      /** Customer's current active biling cycle. */
+      billing_cycle: components['schemas']['BillingCycleDate'];
     };
     CustomerPortalActiveSubscriptionInputArgs: {
-      add_ons?: components['schemas']['SubscriptionAddOnInput'][] | null;
       price_plan_uuid?: string;
+      add_ons?: components['schemas']['SubscriptionAddOnInput'][] | null;
     };
     CustomerPortalSubscription: {
       price_plan?: components['schemas']['PricePlan'];
@@ -3998,115 +4040,121 @@ export interface components {
       price_plan_name?: string;
     };
     CustomerPortalStripeCredential: {
+      client_secret?: string;
       account_id?: string;
       publishable_key?: string;
-      client_secret?: string;
     };
     CustomerPortalMeterLabels: {
+      key?: string;
       /** Primary label values associated with the key */
       values?: string[];
-      key?: string;
     };
     CustomerPortalLabelDisplayName: {
-      display_name?: string;
       /** The raw value of the label data */
       name?: string;
+      display_name?: string;
     };
     CustomerPortalMeterLabelsWithDisplayName: {
-      /** Primary label values associated with the key */
-      values?: components['schemas']['CustomerPortalLabelDisplayName'][];
       /** Primary label key and prettified version of the key */
       key?: components['schemas']['CustomerPortalLabelDisplayName'];
+      /** Primary label values associated with the key */
+      values?: components['schemas']['CustomerPortalLabelDisplayName'][];
     };
     CustomerPortalMeter: {
-      /** Primary labels with keys and values */
-      labels?: components['schemas']['CustomerPortalMeterLabels'][];
-      /** The raw and prettified label keys and values */
-      labels_with_display_names?: components['schemas']['CustomerPortalMeterLabelsWithDisplayName'][];
-      /** Name of the meter. */
-      meter_name?: string;
-      /** Name of the unit the meter uses. */
-      unit_name?: string;
-      /** Display name of the meter. */
-      meter_display_name?: string;
       /** Type of the meter. E.g. COUNTER or GAUGE. */
       meter_type?: string;
+      /** Name of the unit the meter uses. */
+      unit_name?: string;
+      /** Name of the meter. */
+      meter_name?: string;
+      /** Primary labels with keys and values */
+      labels?: components['schemas']['CustomerPortalMeterLabels'][];
+      /** Display name of the meter. */
+      meter_display_name?: string;
+      /** The raw and prettified label keys and values */
+      labels_with_display_names?: components['schemas']['CustomerPortalMeterLabelsWithDisplayName'][];
     };
     DailyUsage: {
-      /** Start of the 24 hour time window in UTC. */
-      time?: string;
+      /** Label key. Only present if label_group_by is provided. */
+      label_key?: string;
       /** Total usage during this window. */
       usage?: number;
+      /** Start of the 24 hour time window in UTC. */
+      time?: string;
+      /** Label value. Only present if label_group_by is provided. */
+      label_value?: string;
     };
     CycleUsage: {
-      usage_by_time?: components['schemas']['DailyUsage'][];
-      /** Total usage in the cycle. */
-      total_usage?: number;
       /** The end of the billing cycle in UTC. */
       cycle_end?: string;
+      usage_by_time?: components['schemas']['DailyUsage'][];
       /** The start of the billing cycle in UTC. */
       cycle_start?: string;
+      /** Total usage in the cycle. */
+      total_usage?: number;
     };
     CustomerPortalUsage: {
-      /** Daily usage across the current billing cycle. */
-      current_cycle_usage?: components['schemas']['CycleUsage'];
+      /** Type of the meter. E.g. COUNTER or GAUGE. */
+      meter_type?: string;
+      /** Name of the unit the meter uses. */
+      unit_name?: string;
       /** Daily usage across the previous billing cycle. */
       previous_cycle_usage?: components['schemas']['CycleUsage'];
       /** Name of the meter. */
       meter_name?: string;
-      /** Name of the unit the meter uses. */
-      unit_name?: string;
+      /** Daily usage across the current billing cycle. */
+      current_cycle_usage?: components['schemas']['CycleUsage'];
       /** Display name of the meter. */
       meter_display_name?: string;
-      /** Type of the meter. E.g. COUNTER or GAUGE. */
-      meter_type?: string;
     };
     CustomerPortalLabelFilter: {
+      key?: string;
       /** Primary label value associated with the key */
       value?: string;
-      key?: string;
     };
     CustomerPortalMeterLabelFilter: {
+      /** Primary labels with keys and values */
+      label_filters?: components['schemas']['CustomerPortalLabelFilter'][];
       /** Name of the meter. */
       meter_name: string;
+      /** The label key to group results by. */
+      label_group_by?: string;
       /** The aggregate function to use for the meter. */
       aggregate?: 'sum' | 'time_weighted' | 'latest';
-      /** Primary labels with keys and values */
-      label_filters: components['schemas']['CustomerPortalLabelFilter'][];
-    };
-    CardInfo: {
-      external_id?: string;
-      /** Last 4 digits of the card. */
-      last4?: string;
-      /** Brand of card. E.g. Amex, Visa, etc. */
-      brand?: string;
-      /** Country of the card */
-      country?: string;
-      /** Month the card expires */
-      exp_month?: number;
-      /** Year the card expires */
-      exp_year?: number;
     };
     BankAccountInfo: {
-      external_id?: string;
-      /** Last 4 digits of the bank account number. */
-      last4?: string;
-      /** Bank account type. E.g. Savings/Checking */
-      account_type?: string;
       /** Country the bank account is in. */
       country?: string;
       /** Name of the bank */
       bank_name?: string;
+      external_id?: string;
+      /** Bank account type. E.g. Savings/Checking */
+      account_type?: string;
       /** Routing number for the bank accopunt */
       routing_number?: number;
+      /** Last 4 digits of the bank account number. */
+      last4?: string;
+    };
+    CardInfo: {
+      /** Country of the card */
+      country?: string;
+      /** Month the card expires */
+      exp_month?: number;
+      external_id?: string;
+      /** Brand of card. E.g. Amex, Visa, etc. */
+      brand?: string;
+      /** Year the card expires */
+      exp_year?: number;
+      /** Last 4 digits of the card. */
+      last4?: string;
     };
     CustomerPortalPaymentMethod: {
-      /** Info about the customer's card, if that is their payment method. */
-      card_info?: components['schemas']['CardInfo'];
       /** Type of payment method for the customer. */
       payment_method_type?: string;
       /** Info about the customer's US bank account, if that is their payment method. */
       bank_account_info?: components['schemas']['BankAccountInfo'];
+      /** Info about the customer's card, if that is their payment method. */
+      card_info?: components['schemas']['CardInfo'];
     };
     SelfServeSettings: {
       /** True if the customer can purchase credits via self serve. Defaults to False. */
@@ -4127,35 +4175,35 @@ export interface components {
       settings: { [key: string]: string };
     };
     CreditLedger: {
-      /** Credit balance as of this change */
-      balance?: number;
+      pending?: boolean;
       /** The change in numer of credits */
       amount?: number;
+      /** Credit balance as of this change */
+      balance?: number;
       /** The time at which this credit balance change occurred. */
       timestamp?: string;
-      pending?: boolean;
     };
     CustomerPortalCreditPurchase: {
       /** Number of credits to purchase. */
       amount: number;
     };
     CreditGrant: {
+      /** The source of the grant. */
+      source?: string;
+      /** The date at which this grant expires */
+      expires_at?: string;
+      /** Optional description. This is only viewable internally */
+      description?: string;
+      /** The date at which this grant is effective */
+      effective_at?: string;
       /** Total price paid for the credits, in cents */
       price?: number;
       /** Number of credits granted */
       amount?: number;
-      /** The date at which this grant is effective */
-      effective_at?: string;
-      /** The date at which this grant expires */
-      expires_at?: string;
-      /** The source of the grant. */
-      source?: string;
       /** A unique identifier for this grant */
       uuid?: string;
       /** Name of the customer who received the grant */
       customer_name?: string;
-      /** Optional description. This is only viewable internally */
-      description?: string;
     };
     Webhook: {
       /** The url to send the webhooks to. */
@@ -4166,45 +4214,45 @@ export interface components {
       enable_signature: boolean;
     };
     CreateWebhookArgs: {
-      url?: string;
       enable_signature?: boolean;
+      url?: string;
     };
     ListCreditGrantsArgs: {
-      /** The number of items to fetch. Defaults to 10. */
-      limit?: number;
-      sort_direction?: string;
-      sort_column?: string;
-      /** Customer to filter the results to */
-      customer_name?: string;
       /** The sort column offset to start at when paging forwards */
       forward_sort_offset?: string;
+      sort_direction?: string;
+      sort_column?: string;
       /** The unique offset to start at when paging forwards */
       forward_secondary_sort_offset?: string;
-    };
-    ListCreditGrants: {
+      /** Customer to filter the results to */
+      customer_name?: string;
       /** The number of items to fetch. Defaults to 10. */
       limit?: number;
-      sort_direction?: string;
-      sort_column?: string;
+    };
+    ListCreditGrants: {
       /** The sort column offset to start at when paging forwards */
       forward_sort_offset?: string;
+      sort_direction?: string;
+      sort_column?: string;
       /** The unique offset to start at when paging forwards */
       forward_secondary_sort_offset?: string;
       credit_grants?: components['schemas']['CreditGrant'][];
+      /** The number of items to fetch. Defaults to 10. */
+      limit?: number;
     };
     CreateCreditGrantArgs: {
-      /** Total price paid for the credits in cents. Defaults to $1 (100 cents) per credit if not specified */
-      price?: number;
       /** The date at which this grant expires */
       expires_at?: string;
-      /** Number of credits to grant */
-      amount: number;
-      /** The date at which the grant is effective */
-      effective_at?: string;
-      /** Name of the customer receving the grant */
-      customer_name: string;
       /** Optional description. This is only viewable internally */
       description?: string;
+      /** The date at which the grant is effective */
+      effective_at?: string;
+      /** Total price paid for the credits in cents. Defaults to $1 (100 cents) per credit if not specified */
+      price?: number;
+      /** Number of credits to grant */
+      amount: number;
+      /** Name of the customer receving the grant */
+      customer_name: string;
     };
     RollApiKeyArgs: {
       /** The date at which this API key will expire. Will default to 7 days. */
@@ -4213,145 +4261,145 @@ export interface components {
       api_key: string;
     };
     RollApiKeys: {
-      success?: boolean;
       /** The newly generated API Key. */
       api_key?: string;
+      success?: boolean;
     };
     UpdateSelfServeSettingsArgs: {
-      /** True if the customer can purchase credits via self serve. Defaults to False. */
-      purchase_credits?: boolean;
-      /** True if the customer can switch their current price plan via self serve. Defaults to False. */
-      switch_price_plans?: boolean;
       /** Time length of the default expiration for credits bought in the customer portal. */
       credits_expiration_length?: number;
+      /** True if the customer can switch their current price plan via self serve. Defaults to False. */
+      switch_price_plans?: boolean;
       /** Price per credit, in cents, that the customer is charged for buying credits through the customer portal */
       price_per_credit_cents?: number;
       /** Time length unit for the default expiration for credits bought in the customer portal. */
       credits_expiration_unit?: string;
-      /** True if the vendor has enabled customization for their customer portal. */
-      customization?: boolean;
+      /** True if the customer can purchase credits via self serve. Defaults to False. */
+      purchase_credits?: boolean;
       /** True if the vendor has enabled customization for their customer portal. */
       enabled?: boolean;
+      /** True if the vendor has enabled customization for their customer portal. */
+      customization?: boolean;
     };
     VendorAvalaraSettings: {
-      /** Enable/Disable the Avalara integration. */
-      enable_integration?: boolean;
       /** Password of the Avalara account. */
       password?: string;
-      /** The Avalara company code string to associate the Octane vendor with. */
-      company_code?: string;
-      /** True if connecting to Avalara sandbox account, false otherwise. */
-      sandbox_mode?: boolean;
-      /** The Avalara item code to use to represent all the line items on the Octane invoice. */
-      item_code?: string;
-      /** True if the documents generated in Avalara should be committed, false otherwise. */
-      commit_documents?: boolean;
-      /** True if enabling logging for Avalara calls, false otherwise. */
-      enable_logging?: boolean;
-      /** Username of the Avalara account. */
-      username?: string;
+      /** Enable/Disable the Avalara integration. */
+      enable_integration?: boolean;
       /** The item description to use to represent all the lines on the Octane invoice. */
       item_description?: string;
       /** he tax code to associate with the item that is representing the Octane invoice. */
       tax_code?: string;
-    };
-    CreateVendorAvalaraSettingsArgs: {
-      /** Enable/Disable the Avalara integration. */
-      enable_integration: boolean;
-      /** Password of the Avalara account. */
-      password: string;
-      /** The Avalara company code string to associate the Octane vendor with. */
-      company_code?: string;
-      /** True if connecting to Avalara sandbox account, false otherwise. */
-      sandbox_mode: boolean;
+      /** True if the documents generated in Avalara should be committed, false otherwise. */
+      commit_documents?: boolean;
       /** The Avalara item code to use to represent all the line items on the Octane invoice. */
       item_code?: string;
-      /** True if the documents generated in Avalara should be committed, false otherwise. Defaults to False. */
-      commit_documents?: boolean;
-      /** True if enabling logging for Avalara calls, false otherwise. Defaults to False. */
-      enable_logging?: boolean;
+      /** True if connecting to Avalara sandbox account, false otherwise. */
+      sandbox_mode?: boolean;
+      /** The Avalara company code string to associate the Octane vendor with. */
+      company_code?: string;
       /** Username of the Avalara account. */
-      username: string;
+      username?: string;
+      /** True if enabling logging for Avalara calls, false otherwise. */
+      enable_logging?: boolean;
+    };
+    CreateVendorAvalaraSettingsArgs: {
+      /** Password of the Avalara account. */
+      password: string;
+      /** Enable/Disable the Avalara integration. */
+      enable_integration: boolean;
       /** The item description to use to represent all the lines on the Octane invoice. */
       item_description?: string;
       /** The tax code to associate with the item that is representing the Octane invoice. */
       tax_code?: string;
+      /** True if the documents generated in Avalara should be committed, false otherwise. Defaults to False. */
+      commit_documents?: boolean;
+      /** The Avalara item code to use to represent all the line items on the Octane invoice. */
+      item_code?: string;
+      /** True if connecting to Avalara sandbox account, false otherwise. */
+      sandbox_mode: boolean;
+      /** The Avalara company code string to associate the Octane vendor with. */
+      company_code?: string;
+      /** Username of the Avalara account. */
+      username: string;
+      /** True if enabling logging for Avalara calls, false otherwise. Defaults to False. */
+      enable_logging?: boolean;
     };
     UpdateVendorAvalaraSettingsArgs: {
       /** Enable/Disable the Avalara integration. */
       enable_integration?: boolean;
-      /** The Avalara company code string to associate the Octane vendor with. */
-      company_code?: string;
-      /** The Avalara item code to use to represent all the line items on the Octane invoice. */
-      item_code?: string;
-      /** True if the documents generated in Avalara should be committed, false otherwise. */
-      commit_documents?: boolean;
-      /** True if enabling logging for Avalara calls, false otherwise. */
-      enable_logging?: boolean;
       /** The item description to use to represent all the lines on the Octane invoice. */
       item_description?: string;
       /** he tax code to associate with the item that is representing the Octane invoice. */
       tax_code?: string;
+      /** True if the documents generated in Avalara should be committed, false otherwise. */
+      commit_documents?: boolean;
+      /** The Avalara item code to use to represent all the line items on the Octane invoice. */
+      item_code?: string;
+      /** The Avalara company code string to associate the Octane vendor with. */
+      company_code?: string;
+      /** True if enabling logging for Avalara calls, false otherwise. */
+      enable_logging?: boolean;
     };
     ValidateCredentialsArgs: {
-      /** Username of the Avalara account */
-      username: string;
       /** Password of the Avalara account */
       password: string;
       /** True if using a Avalara sandbox account, False otherwise */
       sandbox_mode: boolean;
+      /** Username of the Avalara account */
+      username: string;
     };
     ValidateCredentialsResp: {
       /** Indicates whether the ping to Avalara was successful and the credentials were validated. */
       success?: boolean;
     };
     TaxCode: {
-      /** The type of this tax code. */
-      tax_code_type_id?: string;
-      /** The Avalara Entity Use Code represented by this tax code. */
-      entity_use_code?: string;
-      /** The unique ID number of this tax code. */
-      id?: string;
-      /** A friendly description of this tax code. */
-      description?: string;
       /** A code string that identifies this tax code. */
       tax_code?: string;
+      /** The Avalara Entity Use Code represented by this tax code. */
+      entity_use_code?: string;
+      /** A friendly description of this tax code. */
+      description?: string;
+      /** The unique ID number of this tax code. */
+      id?: string;
+      /** The type of this tax code. */
+      tax_code_type_id?: string;
     };
     Company: {
-      /** This flag is true if this company is the default company for this account. */
-      is_default?: boolean;
+      /** This flag indicates whether tax activity can occur for this company. */
+      is_active?: boolean;
+      /** The name of this company, as shown to customers. */
+      company_name?: string;
       /** The unique ID number of this company. */
       id?: string;
       /** A unique code that references this company within your account. */
       company_code?: string;
-      /** The name of this company, as shown to customers. */
-      company_name?: string;
-      /** This flag indicates whether tax activity can occur for this company. */
-      is_active?: boolean;
+      /** This flag is true if this company is the default company for this account. */
+      is_default?: boolean;
     };
     EntityUseCode: {
-      /** Text describing the meaning of this use code. */
-      description?: string;
-      /** The Avalara-recognized entity use code for this definition. */
-      code?: string;
-      /** A list of countries where this use code is valid. */
-      valid_countries?: string[];
       /** The name of this entity use code. */
       name?: string;
+      /** A list of countries where this use code is valid. */
+      valid_countries?: string[];
+      /** The Avalara-recognized entity use code for this definition. */
+      code?: string;
+      /** Text describing the meaning of this use code. */
+      description?: string;
     };
     RevenueRecognitionInput: {
       /** List of customer names for which to compute booked/recognized revenue. */
       customer_names?: string[];
     };
     RevenueRecognitionEntry: {
-      /** The change in deferred revenue this month (in cents). */
-      deferred?: number;
-      /** The newly booked amount in this month (in cents). */
-      booked?: number;
-      /** The month in which the revenue is booked and(or) recognized. */
-      month?: string;
       /** The change in recognized revenue this month (in cents). */
       recognized?: number;
+      /** The newly booked amount in this month (in cents). */
+      booked?: number;
+      /** The change in deferred revenue this month (in cents). */
+      deferred?: number;
+      /** The month in which the revenue is booked and(or) recognized. */
+      month?: string;
     };
   };
   responses: {

--- a/src/hooks/useActiveSubscription.tsx
+++ b/src/hooks/useActiveSubscription.tsx
@@ -16,7 +16,9 @@ export type ActiveSubscriptionInputArgs =
 
 export type UseActiveSubscriptionReturnType =
   UseAsyncFetchReturnType<ActiveSubscription> & {
-    update: (pricePlanInfo: ActiveSubscriptionInputArgs) => void;
+    update: (
+      pricePlanInfo: ActiveSubscriptionInputArgs
+    ) => Promise<ActivePricePlan>;
   };
 
 /**
@@ -59,6 +61,9 @@ export const useActiveSubscription = (args?: {
   return {
     ...hook,
     update: (pricePlanInfo: ActiveSubscriptionInputArgs) =>
-      updateFn(pricePlanInfo).then(() => hook.refetch()),
+      updateFn(pricePlanInfo).then((result) => {
+        hook.refetch();
+        return result;
+      }),
   };
 };

--- a/src/hooks/useActiveSubscription.tsx
+++ b/src/hooks/useActiveSubscription.tsx
@@ -58,8 +58,7 @@ export const useActiveSubscription = (args?: {
   const hook = useAsync(fetchFn);
   return {
     ...hook,
-    update: (pricePlanInfo: ActiveSubscriptionInputArgs) => {
-      updateFn(pricePlanInfo).then(() => hook.refetch());
-    },
+    update: (pricePlanInfo: ActiveSubscriptionInputArgs) =>
+      updateFn(pricePlanInfo).then(() => hook.refetch()),
   };
 };

--- a/src/hooks/useActiveSubscription.tsx
+++ b/src/hooks/useActiveSubscription.tsx
@@ -55,7 +55,7 @@ export const useActiveSubscription = (args?: {
     [userToken, options, baseApiUrl]
   );
 
-  const hook = useAsync(fetchFn);
+  const hook = useAsync({ fetchFn });
   return {
     ...hook,
     update: (pricePlanInfo: ActiveSubscriptionInputArgs) =>

--- a/src/hooks/useActiveSubscription.tsx
+++ b/src/hooks/useActiveSubscription.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useContext } from 'react';
 import getActiveSubscription from '../actions/getActiveSubscription';
 import { useAsync } from './useAsync';
-import type { UseAsyncReturnType } from './useAsync';
+import type { UseAsyncFetchReturnType } from './useAsync';
 import { TokenContext } from './useCustomerToken';
 import { components } from '../apiTypes';
 
@@ -9,7 +9,7 @@ type ActiveSubscription =
   components['schemas']['CustomerPortalActiveSubscription'];
 
 export type UseActiveSubscriptionReturnType =
-  UseAsyncReturnType<ActiveSubscription>;
+  UseAsyncFetchReturnType<ActiveSubscription>;
 
 /**
  * A hook that fetches the customer's active subscription information.

--- a/src/hooks/useActiveSubscription.tsx
+++ b/src/hooks/useActiveSubscription.tsx
@@ -23,7 +23,8 @@ export type UseActiveSubscriptionReturnType =
 
 /**
  * @description
- * A `useActiveSubscription` hook allow to fetch, refetch and update the customer's active subscription data.
+ * A `useActiveSubscription` hook to fetch, refetch, and update the customer's active subscription.
+ *
  * @example
  * const { result, loading, error, refetch, update } = useActiveSubscription({ token });
  */

--- a/src/hooks/useActiveSubscription.tsx
+++ b/src/hooks/useActiveSubscription.tsx
@@ -1,34 +1,65 @@
-import { useCallback, useContext } from 'react';
+import { useCallback, useContext, useMemo } from 'react';
 import getActiveSubscription from '../actions/getActiveSubscription';
 import { useAsync } from './useAsync';
 import type { UseAsyncFetchReturnType } from './useAsync';
 import { TokenContext } from './useCustomerToken';
 import { components } from '../apiTypes';
+import subscribeCustomer from '../actions/subscribeCustomer';
+import type { SubscribeCustomerOptions } from '../actions/subscribeCustomer';
 
 type ActiveSubscription =
   components['schemas']['CustomerPortalActiveSubscription'];
+export type ActivePricePlan =
+  components['schemas']['CustomerPortalSubscription'];
+export type ActiveSubscriptionInputArgs =
+  components['schemas']['CustomerPortalActiveSubscriptionInputArgs'];
 
 export type UseActiveSubscriptionReturnType =
-  UseAsyncFetchReturnType<ActiveSubscription>;
+  UseAsyncFetchReturnType<ActiveSubscription> & {
+    update: (pricePlanInfo: ActiveSubscriptionInputArgs) => void;
+  };
 
 /**
  * A hook that fetches the customer's active subscription information.
  */
+
 export const useActiveSubscription = (args?: {
   token?: string;
   baseApiUrl?: string;
+  options?: SubscribeCustomerOptions;
 }): UseActiveSubscriptionReturnType => {
   const { token: tokenFromContext } = useContext(TokenContext);
   const userToken = args?.token || tokenFromContext;
   const baseApiUrl = args?.baseApiUrl;
+  const options = useMemo(() => args?.options || {}, [args?.options]);
 
   if (!userToken) {
     throw new Error('Token must be provided.');
   }
 
-  const asyncFunc = useCallback(() => {
+  const fetchFn = useCallback(() => {
     return getActiveSubscription(userToken, { baseApiUrl });
   }, [userToken, baseApiUrl]);
 
-  return useAsync(asyncFunc);
+  const updateFn = useCallback(
+    (pricePlanInfo: ActiveSubscriptionInputArgs) => {
+      if (!pricePlanInfo?.price_plan_uuid) {
+        throw new Error('Price plan uuid must be provided.');
+      }
+
+      return subscribeCustomer(userToken, pricePlanInfo, {
+        ...options,
+        baseApiUrl,
+      });
+    },
+    [userToken, options, baseApiUrl]
+  );
+
+  const hook = useAsync(fetchFn);
+  return {
+    ...hook,
+    update: (pricePlanInfo: ActiveSubscriptionInputArgs) => {
+      updateFn(pricePlanInfo).then(() => hook.refetch());
+    },
+  };
 };

--- a/src/hooks/useActiveSubscription.tsx
+++ b/src/hooks/useActiveSubscription.tsx
@@ -22,9 +22,11 @@ export type UseActiveSubscriptionReturnType =
   };
 
 /**
- * A hook that fetches the customer's active subscription information.
+ * @description
+ * A `useActiveSubscription` hook allow to fetch, refetch and update the customer's active subscription data.
+ * @example
+ * const { result, loading, error, refetch, update } = useActiveSubscription({ token });
  */
-
 export const useActiveSubscription = (args?: {
   token?: string;
   baseApiUrl?: string;

--- a/src/hooks/useAsync.ts
+++ b/src/hooks/useAsync.ts
@@ -39,6 +39,7 @@ export type UseAsyncFetchReturnType<
 >;
 
 /**
+ * @description
  * Given a function that returns a promise, provide a hook that exposes the
  * promise's result, error, loading state, refetch function and optional function to update data.
  * This hook takes advantage of discriminated TypeScript unions for its return type; only one of `result`

--- a/src/hooks/useAsync.ts
+++ b/src/hooks/useAsync.ts
@@ -44,40 +44,41 @@ export type UseAsyncFetchReturnType<
  * discriminated TypeScript unions for its return type; only one of `result`
  * and `error` can be set at a time.
  */
-export function useAsync<Result, Error>(
-  fetchFn: () => Promise<Result | null>
-): UseAsyncFetchReturnType<Result, [], Error>;
-export function useAsync<Result, UpdateArgs extends unknown[], Error>(
-  fetchFn: () => Promise<Result | null>,
-  updateFn: (...args: UpdateArgs) => Promise<Result>
-): UseAsyncFetchAndUpdateReturnType<Result, [], UpdateArgs, Error>;
-export function useAsync<Result, FetchArgs extends unknown[], Error>(
-  fetchFn: (...args: FetchArgs) => Promise<Result | null>,
-  initialArgs: FetchArgs
-): UseAsyncFetchReturnType<Result, FetchArgs, Error>;
+export function useAsync<Result, Error>(args: {
+  fetchFn: () => Promise<Result | null>;
+}): UseAsyncFetchReturnType<Result, [], Error>;
+export function useAsync<Result, UpdateArgs extends unknown[], Error>(args: {
+  fetchFn: () => Promise<Result | null>;
+  updateFn: (...args: UpdateArgs) => Promise<Result>;
+}): UseAsyncFetchAndUpdateReturnType<Result, [], UpdateArgs, Error>;
+export function useAsync<Result, FetchArgs extends unknown[], Error>(args: {
+  fetchFn: (...args: FetchArgs) => Promise<Result | null>;
+  initialArgs: FetchArgs;
+}): UseAsyncFetchReturnType<Result, FetchArgs, Error>;
 export function useAsync<
   Result,
   FetchArgs extends unknown[],
   UpdateArgs extends unknown[],
   Error
->(
-  fetchFn: (...args: FetchArgs) => Promise<Result | null>,
-  initialArgs: FetchArgs,
-  updateFn: (...args: UpdateArgs) => Promise<Result>
-): UseAsyncFetchAndUpdateReturnType<Result, FetchArgs, UpdateArgs, Error>;
+>(args: {
+  fetchFn: (...args: FetchArgs) => Promise<Result | null>;
+  initialArgs: FetchArgs;
+  updateFn: (...args: UpdateArgs) => Promise<Result>;
+}): UseAsyncFetchAndUpdateReturnType<Result, FetchArgs, UpdateArgs, Error>;
 
 export function useAsync<
   Result,
   FetchArgs extends unknown[],
   UpdateArgs extends unknown[],
   Error
->(
-  fetchFn: (...args: FetchArgs | []) => Promise<Result | null>,
-  initialArgs?: FetchArgs,
-  updateFn?: (...args: UpdateArgs) => Promise<Result>
-):
+>(args: {
+  fetchFn: (...args: FetchArgs | []) => Promise<Result | null>;
+  initialArgs?: FetchArgs;
+  updateFn?: (...args: UpdateArgs) => Promise<Result>;
+}):
   | UseAsyncFetchReturnType<Result, FetchArgs, Error>
   | UseAsyncFetchAndUpdateReturnType<Result, FetchArgs, UpdateArgs, Error> {
+  const { fetchFn, initialArgs, updateFn } = args;
   const [loading, setLoading] = useState(true);
   const [result, setResult] = useState<Result | null>(null);
   const [error, setError] = useState<Error | null>(null);
@@ -133,6 +134,6 @@ export const createApiHook = <FetchArgs extends unknown[], Result>(
   apiMethod: (...args: FetchArgs) => Promise<Result>
 ) => {
   return function useApiHook(...args: FetchArgs) {
-    return useAsync(() => apiMethod(...args));
+    return useAsync({ fetchFn: () => apiMethod(...args) });
   };
 };

--- a/src/hooks/useAsync.ts
+++ b/src/hooks/useAsync.ts
@@ -3,7 +3,7 @@ import { useState, useEffect, useCallback } from 'react';
 
 export type UseAsyncReturnType<
   Result,
-  Args extends unknown[] = [],
+  FetchArgs extends unknown[] = [],
   Error = unknown
 > =
   | {
@@ -16,13 +16,13 @@ export type UseAsyncReturnType<
       loading: boolean;
       result: Result;
       error: null;
-      refetch: (...args: Args | []) => void;
+      refetch: (...args: FetchArgs | []) => void;
     }
   | {
       loading: boolean;
       result: null;
       error: Error;
-      refetch: (...args: Args | []) => void;
+      refetch: (...args: FetchArgs | []) => void;
     };
 
 /**
@@ -34,26 +34,26 @@ export type UseAsyncReturnType<
 export function useAsync<Result, Error>(
   fetchFn: () => Promise<Result>
 ): UseAsyncReturnType<Result, [], Error>;
-export function useAsync<Result, Args extends unknown[], Error>(
-  fetchFn: (...args: Args) => Promise<Result>,
-  initialArgs: Args
-): UseAsyncReturnType<Result, Args, Error>;
+export function useAsync<Result, FetchArgs extends unknown[], Error>(
+  fetchFn: (...args: FetchArgs) => Promise<Result>,
+  initialArgs: FetchArgs
+): UseAsyncReturnType<Result, FetchArgs, Error>;
 
-export function useAsync<Result, Args extends unknown[], Error>(
-  fetchFn: (...args: Args | []) => Promise<Result>,
-  initialArgs?: Args
-): UseAsyncReturnType<Result, Args | [], Error> {
-  const [result, setResult] = useState<UseAsyncReturnType<Result, Args, Error>>(
-    {
-      loading: true,
-      result: null,
-      error: null,
-      refetch: null,
-    }
-  );
+export function useAsync<Result, FetchArgs extends unknown[], Error>(
+  fetchFn: (...args: FetchArgs | []) => Promise<Result>,
+  initialArgs?: FetchArgs
+): UseAsyncReturnType<Result, FetchArgs | [], Error> {
+  const [result, setResult] = useState<
+    UseAsyncReturnType<Result, FetchArgs, Error>
+  >({
+    loading: true,
+    result: null,
+    error: null,
+    refetch: null,
+  });
 
   const refetch = useCallback(
-    (...args: Args | []) => {
+    (...args: FetchArgs | []) => {
       setResult({ ...result, loading: true });
       fetchFn(...args)
         .then((result) => {
@@ -87,10 +87,10 @@ export function useAsync<Result, Args extends unknown[], Error>(
   return result;
 }
 
-export const createApiHook = <Args extends unknown[], Result>(
-  apiMethod: (...args: Args) => Promise<Result>
+export const createApiHook = <FetchArgs extends unknown[], Result>(
+  apiMethod: (...args: FetchArgs) => Promise<Result>
 ) => {
-  return function useApiHook(...args: Args) {
+  return function useApiHook(...args: FetchArgs) {
     return useAsync(() => apiMethod(...args));
   };
 };

--- a/src/hooks/useAsync.ts
+++ b/src/hooks/useAsync.ts
@@ -8,12 +8,12 @@ export type UseAsyncReturnType<Result, Error = unknown> =
       error: null;
     }
   | {
-      loading: false;
+      loading: boolean;
       result: Result;
       error: null;
     }
   | {
-      loading: false;
+      loading: boolean;
       result: null;
       error: Error;
     };
@@ -21,9 +21,8 @@ export type UseAsyncReturnType<Result, Error = unknown> =
 /**
  * Given a function that returns a promise, provide a hook that exposes the
  * promise's result, error, and loading state. This hook takes advantage of
- * discriminated TypeScript unions for its return type; if `loading` is true,
- * then `error` and `null` are necessarily `null`. If `loading` or `error` are
- * null
+ * discriminated TypeScript unions for its return type; only one of `result`
+ * and `error` can be set at a time.
  */
 export const useAsync = <Result, Error>(
   asyncFn: () => Promise<Result>
@@ -35,6 +34,7 @@ export const useAsync = <Result, Error>(
   });
 
   useEffect(() => {
+    setResult({ ...result, loading: true });
     asyncFn()
       .then((result) => {
         setResult({ result, error: null, loading: false });
@@ -42,7 +42,7 @@ export const useAsync = <Result, Error>(
       .catch((error) => {
         setResult({ result: null, error, loading: false });
       });
-  }, [asyncFn]);
+  }, [asyncFn, result]);
 
   return result;
 };

--- a/src/hooks/useAsync.ts
+++ b/src/hooks/useAsync.ts
@@ -40,10 +40,13 @@ export type UseAsyncFetchReturnType<
 
 /**
  * @description
- * Given a function that returns a promise, provide a hook that exposes the
- * promise's result, error, loading state, refetch function and optional function to update data.
- * This hook takes advantage of discriminated TypeScript unions for its return type; only one of `result`
- * and `error` can be set at a time.
+ * Given a function that returns a promise, returns a hook that exposes the
+ * promise's result, error, loading states and provides a refetch function.
+ * When also given an update function, will include it in the return updating
+ * result as necessary.
+ *
+ * This hook takes advantage of discriminated TypeScript unions for its return
+ * type; only one of `result` and `error` can be set at a time.
  */
 export function useAsync<Result, Error>(args: {
   fetchFn: () => Promise<Result | null>;

--- a/src/hooks/useAsync.ts
+++ b/src/hooks/useAsync.ts
@@ -40,8 +40,8 @@ export type UseAsyncFetchReturnType<
 
 /**
  * Given a function that returns a promise, provide a hook that exposes the
- * promise's result, error, and loading state. This hook takes advantage of
- * discriminated TypeScript unions for its return type; only one of `result`
+ * promise's result, error, loading state, refetch function and optional function to update data.
+ * This hook takes advantage of discriminated TypeScript unions for its return type; only one of `result`
  * and `error` can be set at a time.
  */
 export function useAsync<Result, Error>(args: {

--- a/src/hooks/useAsync.ts
+++ b/src/hooks/useAsync.ts
@@ -32,15 +32,15 @@ export type UseAsyncReturnType<
  * and `error` can be set at a time.
  */
 export function useAsync<Result, Error>(
-  asyncFn: () => Promise<Result>
+  fetchFn: () => Promise<Result>
 ): UseAsyncReturnType<Result, [], Error>;
 export function useAsync<Result, Args extends unknown[], Error>(
-  asyncFn: (...args: Args) => Promise<Result>,
+  fetchFn: (...args: Args) => Promise<Result>,
   initialArgs: Args
 ): UseAsyncReturnType<Result, Args, Error>;
 
 export function useAsync<Result, Args extends unknown[], Error>(
-  asyncFn: (...args: Args | []) => Promise<Result>,
+  fetchFn: (...args: Args | []) => Promise<Result>,
   initialArgs?: Args
 ): UseAsyncReturnType<Result, Args | [], Error> {
   const [result, setResult] = useState<UseAsyncReturnType<Result, Args, Error>>(
@@ -55,7 +55,7 @@ export function useAsync<Result, Args extends unknown[], Error>(
   const refetch = useCallback(
     (...args: Args | []) => {
       setResult({ ...result, loading: true });
-      asyncFn(...args)
+      fetchFn(...args)
         .then((result) => {
           setResult({
             result,
@@ -73,7 +73,7 @@ export function useAsync<Result, Args extends unknown[], Error>(
           });
         });
     },
-    [asyncFn, result]
+    [fetchFn, result]
   );
 
   useEffect(() => {

--- a/src/hooks/useContactInfo.tsx
+++ b/src/hooks/useContactInfo.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useContext } from 'react';
 import { useAsync } from './useAsync';
-import type { UseAsyncReturnType } from './useAsync';
+import type { UseAsyncFetchReturnType } from './useAsync';
 import { TokenContext } from './useCustomerToken';
 import { components } from '../apiTypes';
 import getCustomerContactInfo from '../actions/getContactInfo';
 
 type ContactInfo = components['schemas']['ContactInfo'];
 
-export type UseContactInfoReturnType = UseAsyncReturnType<ContactInfo>;
+export type UseContactInfoReturnType = UseAsyncFetchReturnType<ContactInfo>;
 
 /**
  * A hook that fetches the customer's contact info.

--- a/src/hooks/useContactInfo.tsx
+++ b/src/hooks/useContactInfo.tsx
@@ -18,7 +18,8 @@ export type UseContactInfoReturnType = UseAsyncFetchAndUpdateReturnType<
 
 /**
  * @description
- * A `useContactInfo` hook allow to fetch, refetch and update the customer's contact info.
+ * A `useContactInfo` hook to fetch, refetch, and update a customer's contact info.
+ *
  * @example
  * const { result, loading, error, refetch, update } = useContactInfo({ token });
  */

--- a/src/hooks/useContactInfo.tsx
+++ b/src/hooks/useContactInfo.tsx
@@ -4,8 +4,11 @@ import type { UseAsyncFetchReturnType } from './useAsync';
 import { TokenContext } from './useCustomerToken';
 import { components } from '../apiTypes';
 import getCustomerContactInfo from '../actions/getContactInfo';
+import updateCustomerContactInfo from 'actions/updateContactInfo';
 
 type ContactInfo = components['schemas']['ContactInfo'];
+export type ContactInfoInputArgs =
+  components['schemas']['ContactInfoInputArgs'];
 
 export type UseContactInfoReturnType = UseAsyncFetchReturnType<ContactInfo>;
 
@@ -24,9 +27,22 @@ export const useContactInfo = (args?: {
     throw new Error('Token must be provided.');
   }
 
-  const asyncFunc = useCallback(() => {
+  const fetchFn = useCallback(() => {
     return getCustomerContactInfo(userToken, { baseApiUrl });
   }, [userToken, baseApiUrl]);
 
-  return useAsync(asyncFunc);
+  const updateFn = useCallback(
+    (contactInfoToUpdate: ContactInfoInputArgs) => {
+      if (!contactInfoToUpdate) {
+        throw new Error('Contact info object must be provided.');
+      }
+
+      return updateCustomerContactInfo(userToken, contactInfoToUpdate, {
+        baseApiUrl,
+      });
+    },
+    [userToken, baseApiUrl]
+  );
+
+  return useAsync(fetchFn, updateFn);
 };

--- a/src/hooks/useContactInfo.tsx
+++ b/src/hooks/useContactInfo.tsx
@@ -17,7 +17,10 @@ export type UseContactInfoReturnType = UseAsyncFetchAndUpdateReturnType<
 >;
 
 /**
- * A hook that fetches the customer's contact info.
+ * @description
+ * A `useContactInfo` hook allow to fetch, refetch and update the customer's contact info.
+ * @example
+ * const { result, loading, error, refetch, update } = useContactInfo({ token });
  */
 export const useContactInfo = (args?: {
   token?: string;

--- a/src/hooks/useContactInfo.tsx
+++ b/src/hooks/useContactInfo.tsx
@@ -48,5 +48,5 @@ export const useContactInfo = (args?: {
     [userToken, baseApiUrl]
   );
 
-  return useAsync(fetchFn, updateFn);
+  return useAsync({ fetchFn, updateFn });
 };

--- a/src/hooks/useContactInfo.tsx
+++ b/src/hooks/useContactInfo.tsx
@@ -1,16 +1,20 @@
 import { useCallback, useContext } from 'react';
 import { useAsync } from './useAsync';
-import type { UseAsyncFetchReturnType } from './useAsync';
+import type { UseAsyncFetchAndUpdateReturnType } from './useAsync';
 import { TokenContext } from './useCustomerToken';
 import { components } from '../apiTypes';
 import getCustomerContactInfo from '../actions/getContactInfo';
-import updateCustomerContactInfo from 'actions/updateContactInfo';
+import updateCustomerContactInfo from '../actions/updateContactInfo';
 
 type ContactInfo = components['schemas']['ContactInfo'];
 export type ContactInfoInputArgs =
   components['schemas']['ContactInfoInputArgs'];
 
-export type UseContactInfoReturnType = UseAsyncFetchReturnType<ContactInfo>;
+export type UseContactInfoReturnType = UseAsyncFetchAndUpdateReturnType<
+  ContactInfo,
+  [],
+  [ContactInfoInputArgs]
+>;
 
 /**
  * A hook that fetches the customer's contact info.

--- a/src/hooks/useCustomerLink.tsx
+++ b/src/hooks/useCustomerLink.tsx
@@ -1,8 +1,9 @@
-import { useCallback } from 'react';
+import { useCallback, useContext } from 'react';
 import { useAsync } from './useAsync';
 import type { UseAsyncFetchReturnType } from './useAsync';
 import getCustomerLink from '../actions/getCustomerLink';
 import { components } from 'apiTypes';
+import { TokenContext } from './useCustomerToken';
 
 type ContactLink = components['schemas']['CustomerPortalUrl'];
 export type UseContactLinkReturnType = UseAsyncFetchReturnType<ContactLink>;
@@ -10,19 +11,21 @@ export type UseContactLinkReturnType = UseAsyncFetchReturnType<ContactLink>;
 /**
  * A hook that fetches the link to a customer's portal.
  */
-export const useCustomerLink = (args: {
-  token: string;
+export const useCustomerLink = (args?: {
+  token?: string;
   baseApiUrl?: string;
 }): UseContactLinkReturnType => {
-  const { token, baseApiUrl } = args;
+  const { token: tokenFromContext } = useContext(TokenContext);
+  const userToken = args?.token || tokenFromContext;
+  const baseApiUrl = args?.baseApiUrl;
 
-  if (!token) {
+  if (!userToken) {
     throw new Error("Customer's token must be provided.");
   }
 
   const fetchFn = useCallback(() => {
-    return getCustomerLink(token, { baseApiUrl });
-  }, [token, baseApiUrl]);
+    return getCustomerLink(userToken, { baseApiUrl });
+  }, [userToken, baseApiUrl]);
 
   return useAsync({ fetchFn });
 };

--- a/src/hooks/useCustomerLink.tsx
+++ b/src/hooks/useCustomerLink.tsx
@@ -1,11 +1,11 @@
 import { useCallback } from 'react';
 import { useAsync } from './useAsync';
-import type { UseAsyncReturnType } from './useAsync';
+import type { UseAsyncFetchReturnType } from './useAsync';
 import getCustomerLink from '../actions/getCustomerLink';
 import { components } from 'apiTypes';
 
 type ContactLink = components['schemas']['CustomerPortalUrl'];
-export type UseContactLinkReturnType = UseAsyncReturnType<ContactLink>;
+export type UseContactLinkReturnType = UseAsyncFetchReturnType<ContactLink>;
 
 /**
  * A hook that fetches the link to a customer's portal.

--- a/src/hooks/useCustomerLink.tsx
+++ b/src/hooks/useCustomerLink.tsx
@@ -9,7 +9,10 @@ type ContactLink = components['schemas']['CustomerPortalUrl'];
 export type UseContactLinkReturnType = UseAsyncFetchReturnType<ContactLink>;
 
 /**
+ * @description
  * A hook that fetches the link to a customer's portal.
+ * @example
+ * const { result , loading, error, refetch } = useCustomerLink({ token });
  */
 export const useCustomerLink = (args?: {
   token?: string;

--- a/src/hooks/useCustomerLink.tsx
+++ b/src/hooks/useCustomerLink.tsx
@@ -20,9 +20,9 @@ export const useCustomerLink = (args: {
     throw new Error("Customer's token must be provided.");
   }
 
-  const asyncFunc = useCallback(() => {
+  const fetchFn = useCallback(() => {
     return getCustomerLink(token, { baseApiUrl });
   }, [token, baseApiUrl]);
 
-  return useAsync(asyncFunc);
+  return useAsync({ fetchFn });
 };

--- a/src/hooks/useCustomerLink.tsx
+++ b/src/hooks/useCustomerLink.tsx
@@ -10,7 +10,8 @@ export type UseContactLinkReturnType = UseAsyncFetchReturnType<ContactLink>;
 
 /**
  * @description
- * A hook that fetches the link to a customer's portal.
+ * A hook to fetch a customer's portal link url.
+ *
  * @example
  * const { result , loading, error, refetch } = useCustomerLink({ token });
  */

--- a/src/hooks/useCustomerMeters.tsx
+++ b/src/hooks/useCustomerMeters.tsx
@@ -10,7 +10,10 @@ type CustomerPortalMeters = components['schemas']['CustomerPortalMeter'][];
 export type UseMetersReturnType = UseAsyncFetchReturnType<CustomerPortalMeters>;
 
 /**
- * A hook that fetches all price plans associated with a vendor.
+ * @description
+ * A hook that fetches all meters associated with a vendor's price plan.
+ * @example
+ * const { result, loading, error, refetch } = useMeters({ token });
  */
 export const useMeters = (args?: {
   token?: string;

--- a/src/hooks/useCustomerMeters.tsx
+++ b/src/hooks/useCustomerMeters.tsx
@@ -11,7 +11,7 @@ export type UseMetersReturnType = UseAsyncFetchReturnType<CustomerPortalMeters>;
 
 /**
  * @description
- * A hook that fetches all meters associated with a vendor's price plan.
+ * A hook that fetches all meters associated with a vendor's active subscription.
  * @example
  * const { result, loading, error, refetch } = useMeters({ token });
  */

--- a/src/hooks/useCustomerMeters.tsx
+++ b/src/hooks/useCustomerMeters.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useContext } from 'react';
 import getCustomerMeters from '../actions/getCustomerMeters';
 import { useAsync } from './useAsync';
-import type { UseAsyncReturnType } from './useAsync';
+import type { UseAsyncFetchReturnType } from './useAsync';
 import { TokenContext } from './useCustomerToken';
 import { components } from '../apiTypes';
 
 type CustomerPortalMeters = components['schemas']['CustomerPortalMeter'][];
 
-export type UseMetersReturnType = UseAsyncReturnType<CustomerPortalMeters>;
+export type UseMetersReturnType = UseAsyncFetchReturnType<CustomerPortalMeters>;
 
 /**
  * A hook that fetches all price plans associated with a vendor.

--- a/src/hooks/useCustomerMeters.tsx
+++ b/src/hooks/useCustomerMeters.tsx
@@ -24,9 +24,9 @@ export const useMeters = (args?: {
     throw new Error('Token must be provided.');
   }
 
-  const asyncFunc = useCallback(() => {
+  const fetchFn = useCallback(() => {
     return getCustomerMeters(userToken, { baseApiUrl });
   }, [userToken, baseApiUrl]);
 
-  return useAsync(asyncFunc);
+  return useAsync({ fetchFn });
 };

--- a/src/hooks/useCustomerMeters.tsx
+++ b/src/hooks/useCustomerMeters.tsx
@@ -11,7 +11,8 @@ export type UseMetersReturnType = UseAsyncFetchReturnType<CustomerPortalMeters>;
 
 /**
  * @description
- * A hook that fetches all meters associated with a vendor's active subscription.
+ * A hook to fetch the list of meters associated with a customer's active subscription.
+ *
  * @example
  * const { result, loading, error, refetch } = useMeters({ token });
  */

--- a/src/hooks/useCustomerUsage.tsx
+++ b/src/hooks/useCustomerUsage.tsx
@@ -8,7 +8,9 @@ type CustomerPortalMeterLabelFilter =
   components['schemas']['CustomerPortalMeterLabelFilter'];
 
 /**
- * A hook that fetches the customer's usage.
+ * @deprecated use `useUsage` hook instead.
+ * It extends a functionality of `useCustomerUsage` and provide `refetch` function.
+ * Look `hooks/useUsage` for more details.
  */
 export const useCustomerUsage = (args?: {
   token?: string;

--- a/src/hooks/useCustomerUsage.tsx
+++ b/src/hooks/useCustomerUsage.tsx
@@ -9,8 +9,8 @@ type CustomerPortalMeterLabelFilter =
 
 /**
  * @deprecated use `useUsage` hook instead.
- * It extends a functionality of `useCustomerUsage` and provide `refetch` function.
- * Look `hooks/useUsage` for more details.
+ * It is more consistent with the other hooks in this package and provides a
+ * `refetch` function. Please see `hooks/useUsage` for more details.
  */
 export const useCustomerUsage = (args?: {
   token?: string;

--- a/src/hooks/useInvoices.tsx
+++ b/src/hooks/useInvoices.tsx
@@ -24,9 +24,9 @@ export const useInvoices = (args?: {
     throw new Error('Token must be provided.');
   }
 
-  const asyncFunc = useCallback(() => {
+  const fetchFn = useCallback(() => {
     return getInvoices(userToken, { baseApiUrl });
   }, [userToken, baseApiUrl]);
 
-  return useAsync(asyncFunc);
+  return useAsync({ fetchFn });
 };

--- a/src/hooks/useInvoices.tsx
+++ b/src/hooks/useInvoices.tsx
@@ -11,7 +11,8 @@ export type UseInvoicesReturnType = UseAsyncFetchReturnType<Invoices>;
 
 /**
  * @description
- * A hook that fetches the customer's invoices.
+ * A hook to fetch a customer's invoices.
+ *
  * @example
  * const { result, loading, error, refetch } = useInvoices({ token });
  */

--- a/src/hooks/useInvoices.tsx
+++ b/src/hooks/useInvoices.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useContext } from 'react';
 import { useAsync } from './useAsync';
 import getInvoices from '../actions/getInvoices';
-import type { UseAsyncReturnType } from './useAsync';
+import type { UseAsyncFetchReturnType } from './useAsync';
 import { TokenContext } from './useCustomerToken';
 import { components } from '../apiTypes';
 
 type Invoices = components['schemas']['CustomerPortalInvoice'][];
 
-export type UseInvoicesReturnType = UseAsyncReturnType<Invoices>;
+export type UseInvoicesReturnType = UseAsyncFetchReturnType<Invoices>;
 
 /**
  * A hook that fetches the customer's invoices.

--- a/src/hooks/useInvoices.tsx
+++ b/src/hooks/useInvoices.tsx
@@ -10,7 +10,10 @@ type Invoices = components['schemas']['CustomerPortalInvoice'][];
 export type UseInvoicesReturnType = UseAsyncFetchReturnType<Invoices>;
 
 /**
+ * @description
  * A hook that fetches the customer's invoices.
+ * @example
+ * const { result, loading, error, refetch } = useInvoices({ token });
  */
 export const useInvoices = (args?: {
   token?: string;

--- a/src/hooks/usePaymentMethodInfo.tsx
+++ b/src/hooks/usePaymentMethodInfo.tsx
@@ -26,9 +26,9 @@ export const usePaymentMethodInfo = (args?: {
     throw new Error('Token must be provided.');
   }
 
-  const asyncFunc = useCallback(() => {
+  const fetchFn = useCallback(() => {
     return getPaymentMethodInfo(userToken, { baseApiUrl });
   }, [userToken, baseApiUrl]);
 
-  return useAsync(asyncFunc);
+  return useAsync({ fetchFn });
 };

--- a/src/hooks/usePaymentMethodInfo.tsx
+++ b/src/hooks/usePaymentMethodInfo.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useContext } from 'react';
 import getPaymentMethodInfo from '../actions/getPaymentMethodInfo';
 import { useAsync } from './useAsync';
-import type { UseAsyncReturnType } from './useAsync';
+import type { UseAsyncFetchReturnType } from './useAsync';
 import { TokenContext } from './useCustomerToken';
 import { components } from '../apiTypes';
 
@@ -9,7 +9,7 @@ type CustomerPortalPaymentInfo =
   components['schemas']['CustomerPortalPaymentMethod'];
 
 export type UsePaymentMehodInfoReturnType =
-  UseAsyncReturnType<CustomerPortalPaymentInfo>;
+  UseAsyncFetchReturnType<CustomerPortalPaymentInfo>;
 
 /**
  * A hook that fetches the customer's payment method info.

--- a/src/hooks/usePaymentMethodInfo.tsx
+++ b/src/hooks/usePaymentMethodInfo.tsx
@@ -12,7 +12,10 @@ export type UsePaymentMehodInfoReturnType =
   UseAsyncFetchReturnType<CustomerPortalPaymentInfo>;
 
 /**
+ * @description
  * A hook that fetches the customer's payment method info.
+ * @example
+ * const { result, loading, error, refetch } = usePaymentMethodInfo({ token });
  */
 export const usePaymentMethodInfo = (args?: {
   token?: string;

--- a/src/hooks/usePaymentMethodInfo.tsx
+++ b/src/hooks/usePaymentMethodInfo.tsx
@@ -13,7 +13,8 @@ export type UsePaymentMehodInfoReturnType =
 
 /**
  * @description
- * A hook that fetches the customer's payment method info.
+ * A hook to fetch a customer's payment method info.
+ *
  * @example
  * const { result, loading, error, refetch } = usePaymentMethodInfo({ token });
  */

--- a/src/hooks/usePaymentMethodStatus.tsx
+++ b/src/hooks/usePaymentMethodStatus.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useContext } from 'react';
 import getPaymentMethodStatus from '../actions/getPaymentMethodStatus';
 import { useAsync } from './useAsync';
-import type { UseAsyncReturnType } from './useAsync';
+import type { UseAsyncFetchReturnType } from './useAsync';
 import { TokenContext } from './useCustomerToken';
 import { components } from '../apiTypes';
 
@@ -9,7 +9,7 @@ type CustomerPaymentMethodStatus =
   components['schemas']['CustomerPaymentMethodStatus'];
 
 export type UsePaymentMethodStatusReturnType =
-  UseAsyncReturnType<CustomerPaymentMethodStatus>;
+  UseAsyncFetchReturnType<CustomerPaymentMethodStatus>;
 
 /**
  * A hook that fetches customer's payment method status.

--- a/src/hooks/usePaymentMethodStatus.tsx
+++ b/src/hooks/usePaymentMethodStatus.tsx
@@ -12,7 +12,10 @@ export type UsePaymentMethodStatusReturnType =
   UseAsyncFetchReturnType<CustomerPaymentMethodStatus>;
 
 /**
+ * @description
  * A hook that fetches customer's payment method status.
+ * @example
+ * const { result, loading, error, refetch } = usePaymentMethodStatus({ token });
  */
 export const usePaymentMethodStatus = (args?: {
   token?: string;

--- a/src/hooks/usePaymentMethodStatus.tsx
+++ b/src/hooks/usePaymentMethodStatus.tsx
@@ -13,7 +13,8 @@ export type UsePaymentMethodStatusReturnType =
 
 /**
  * @description
- * A hook that fetches customer's payment method status.
+ * A hook to fetch a customer's payment method status.
+ *
  * @example
  * const { result, loading, error, refetch } = usePaymentMethodStatus({ token });
  */

--- a/src/hooks/usePaymentMethodStatus.tsx
+++ b/src/hooks/usePaymentMethodStatus.tsx
@@ -26,9 +26,9 @@ export const usePaymentMethodStatus = (args?: {
     throw new Error('Token must be provided.');
   }
 
-  const asyncFunc = useCallback(() => {
+  const fetchFn = useCallback(() => {
     return getPaymentMethodStatus(userToken, { baseApiUrl });
   }, [userToken, baseApiUrl]);
 
-  return useAsync(asyncFunc);
+  return useAsync({ fetchFn });
 };

--- a/src/hooks/usePricePlans.tsx
+++ b/src/hooks/usePricePlans.tsx
@@ -24,9 +24,9 @@ export const usePricePlans = (args?: {
     throw new Error('Token must be provided.');
   }
 
-  const asyncFunc = useCallback(() => {
+  const fetchFn = useCallback(() => {
     return getAllPricePlans(userToken, { baseApiUrl });
   }, [userToken, baseApiUrl]);
 
-  return useAsync(asyncFunc);
+  return useAsync({ fetchFn });
 };

--- a/src/hooks/usePricePlans.tsx
+++ b/src/hooks/usePricePlans.tsx
@@ -11,7 +11,8 @@ export type UsePricePlansReturnType = UseAsyncFetchReturnType<PricePlan[]>;
 
 /**
  * @description
- * A hook that fetches all price plans associated with a vendor.
+ * A hook to fetch the list of price plans available to a customer.
+ *
  * @example
  * const { result, loading, error, refetch } = usePricePlans({ token });
  */

--- a/src/hooks/usePricePlans.tsx
+++ b/src/hooks/usePricePlans.tsx
@@ -10,7 +10,10 @@ type PricePlan = components['schemas']['PricePlan'];
 export type UsePricePlansReturnType = UseAsyncFetchReturnType<PricePlan[]>;
 
 /**
+ * @description
  * A hook that fetches all price plans associated with a vendor.
+ * @example
+ * const { result, loading, error, refetch } = usePricePlans({ token });
  */
 export const usePricePlans = (args?: {
   token?: string;

--- a/src/hooks/usePricePlans.tsx
+++ b/src/hooks/usePricePlans.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useContext } from 'react';
 import getAllPricePlans from '../actions/getAllPricePlans';
 import { useAsync } from './useAsync';
-import type { UseAsyncReturnType } from './useAsync';
+import type { UseAsyncFetchReturnType } from './useAsync';
 import { TokenContext } from './useCustomerToken';
 import { components } from '../apiTypes';
 
 type PricePlan = components['schemas']['PricePlan'];
 
-export type UsePricePlansReturnType = UseAsyncReturnType<PricePlan[]>;
+export type UsePricePlansReturnType = UseAsyncFetchReturnType<PricePlan[]>;
 
 /**
  * A hook that fetches all price plans associated with a vendor.

--- a/src/hooks/useSelfServeCustomization.tsx
+++ b/src/hooks/useSelfServeCustomization.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useContext } from 'react';
 import { TokenContext } from './useCustomerToken';
 import { useAsync } from './useAsync';
-import type { UseAsyncReturnType } from './useAsync';
+import type { UseAsyncFetchReturnType } from './useAsync';
 import { components } from '../apiTypes';
 import fetchSelfServeCustomization from '../actions/getSelfServeCustomization';
 
 type SelfServeCustomization = components['schemas']['SelfServeCustomization'];
 export type UseSelfServeCustomizationReturnType =
-  UseAsyncReturnType<SelfServeCustomization>;
+  UseAsyncFetchReturnType<SelfServeCustomization>;
 
 /**
  * A hook that fetches the vendor's self-serve customization.

--- a/src/hooks/useSelfServeCustomization.tsx
+++ b/src/hooks/useSelfServeCustomization.tsx
@@ -10,7 +10,10 @@ export type UseSelfServeCustomizationReturnType =
   UseAsyncFetchReturnType<SelfServeCustomization>;
 
 /**
+ * @description
  * A hook that fetches the vendor's self-serve customization.
+ * @example
+ * const { result, loading, error, refetch } = useSelfServeCustomization({ token });
  */
 export const useSelfServeCustomization = (args: {
   token?: string;

--- a/src/hooks/useSelfServeCustomization.tsx
+++ b/src/hooks/useSelfServeCustomization.tsx
@@ -11,7 +11,8 @@ export type UseSelfServeCustomizationReturnType =
 
 /**
  * @description
- * A hook that fetches the vendor's self-serve customization.
+ * A hook to fetch the self-serve customization settings.
+ *
  * @example
  * const { result, loading, error, refetch } = useSelfServeCustomization({ token });
  */

--- a/src/hooks/useSelfServeCustomization.tsx
+++ b/src/hooks/useSelfServeCustomization.tsx
@@ -24,9 +24,9 @@ export const useSelfServeCustomization = (args: {
     throw new Error("Customer's token must be provided.");
   }
 
-  const asyncFunc = useCallback(() => {
+  const fetchFn = useCallback(() => {
     return fetchSelfServeCustomization(userToken, { baseApiUrl });
   }, [userToken, baseApiUrl]);
 
-  return useAsync(asyncFunc);
+  return useAsync({ fetchFn });
 };

--- a/src/hooks/useSelfServeSettings.tsx
+++ b/src/hooks/useSelfServeSettings.tsx
@@ -10,7 +10,10 @@ export type UseSelfServeSettingsReturnType =
   UseAsyncFetchReturnType<SelfServeSettings>;
 
 /**
+ * @description
  * A hook that fetches the vendor's self-serve settings.
+ * @example
+ * const { result, loading, error, refetch } = useSelfServeSettings({ token });
  */
 export const useSelfServeSettings = (args: {
   token?: string;

--- a/src/hooks/useSelfServeSettings.tsx
+++ b/src/hooks/useSelfServeSettings.tsx
@@ -11,7 +11,8 @@ export type UseSelfServeSettingsReturnType =
 
 /**
  * @description
- * A hook that fetches the vendor's self-serve settings.
+ * A hook to fetch the self-serve settings.
+ *
  * @example
  * const { result, loading, error, refetch } = useSelfServeSettings({ token });
  */

--- a/src/hooks/useSelfServeSettings.tsx
+++ b/src/hooks/useSelfServeSettings.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useContext } from 'react';
 import { TokenContext } from './useCustomerToken';
 import { useAsync } from './useAsync';
-import type { UseAsyncReturnType } from './useAsync';
+import type { UseAsyncFetchReturnType } from './useAsync';
 import fetchSelfServeSettings from '../actions/getSelfServeSettings';
 import { components } from '../apiTypes';
 
 type SelfServeSettings = components['schemas']['SelfServeSettings'];
 export type UseSelfServeSettingsReturnType =
-  UseAsyncReturnType<SelfServeSettings>;
+  UseAsyncFetchReturnType<SelfServeSettings>;
 
 /**
  * A hook that fetches the vendor's self-serve settings.

--- a/src/hooks/useSelfServeSettings.tsx
+++ b/src/hooks/useSelfServeSettings.tsx
@@ -24,9 +24,9 @@ export const useSelfServeSettings = (args: {
     throw new Error("Customer's token must be provided.");
   }
 
-  const asyncFunc = useCallback(() => {
+  const fetchFn = useCallback(() => {
     return fetchSelfServeSettings(userToken, { baseApiUrl });
   }, [userToken, baseApiUrl]);
 
-  return useAsync(asyncFunc);
+  return useAsync({ fetchFn });
 };

--- a/src/hooks/useUpdateContactInfo.tsx
+++ b/src/hooks/useUpdateContactInfo.tsx
@@ -13,10 +13,9 @@ type Props = {
 
 /**
  * @deprecated use `useContactInfo` hook instead.
- * It comes with `refetch` and `update` functions.
- * We don't want to create a separate state object for updated data,
- * because it's much difficult to work with.
- * Look `hooks/useContactInfo` for more details.
+ * It is more consistent with the other hooks in this package and provides
+ * `refetch` and `update` functions. When `update` is called, it will keep the
+ * `result` value up to date. Please see `hooks/useContactInfo` for more details.
  */
 export const useUpdateContactInfo = ({ token, baseApiUrl }: Props) => {
   const { token: tokenFromContext } = useContext(TokenContext);

--- a/src/hooks/useUpdateContactInfo.tsx
+++ b/src/hooks/useUpdateContactInfo.tsx
@@ -11,6 +11,13 @@ type Props = {
   baseApiUrl?: string;
 };
 
+/**
+ * @deprecated use `useContactInfo` hook instead.
+ * It comes with `refetch` and `update` functions.
+ * We don't want to create a separate state object for updated data,
+ * because it's much difficult to work with.
+ * Look `hooks/useContactInfo` for more details.
+ */
 export const useUpdateContactInfo = ({ token, baseApiUrl }: Props) => {
   const { token: tokenFromContext } = useContext(TokenContext);
   const userToken = token || tokenFromContext;

--- a/src/hooks/useUpdateSubscription.tsx
+++ b/src/hooks/useUpdateSubscription.tsx
@@ -18,10 +18,10 @@ type Props = {
 
 /**
  * @deprecated use `useActiveSubscription` hook instead.
- * It comes with `refetch` and `update` functions.
- * We don't want to create a separate state object for updated data,
- * because it's much difficult to work with.
- * Look `hooks/useActiveSubscription` for more details.
+ * It is more consistent with the other hooks in this package and provides
+ * `refetch` and `update` functions. When `update` is called, it will refetch
+ * to keep `result` value up to date. Please see `hooks/useActiveSubscription`
+ * for more details.
  */
 export const useUpdateSubscription = ({
   token,

--- a/src/hooks/useUpdateSubscription.tsx
+++ b/src/hooks/useUpdateSubscription.tsx
@@ -16,6 +16,13 @@ type Props = {
   options?: SubscribeCustomerOptions;
 };
 
+/**
+ * @deprecated use `useActiveSubscription` hook instead.
+ * It comes with `refetch` and `update` functions.
+ * We don't want to create a separate state object for updated data,
+ * because it's much difficult to work with.
+ * Look `hooks/useActiveSubscription` for more details.
+ */
 export const useUpdateSubscription = ({
   token,
   baseApiUrl,

--- a/src/hooks/useUsage.tsx
+++ b/src/hooks/useUsage.tsx
@@ -23,7 +23,7 @@ export const useUsage = (args?: {
     throw new Error('Token must be provided.');
   }
 
-  const fetchFunc = useCallback(
+  const fetchFn = useCallback(
     (meterFilter?: CustomerPortalMeterLabelFilter) => {
       if (meterFilter == null) {
         return Promise.resolve(null);
@@ -33,5 +33,5 @@ export const useUsage = (args?: {
     [userToken, baseApiUrl]
   );
 
-  return useAsync(fetchFunc, [args?.meterFilter]);
+  return useAsync({ fetchFn, initialArgs: [args?.meterFilter] });
 };

--- a/src/hooks/useUsage.tsx
+++ b/src/hooks/useUsage.tsx
@@ -9,7 +9,8 @@ type CustomerPortalMeterLabelFilter =
 
 /**
  * @description
- * A `useUsage` hook allow to fetch and refetch the customer's usage data.
+ * A `useUsage` hook to fetch and refetch a customer's usage data.
+ *
  * @example
  * const { result, loading, error, refetch } = useUsage({
  *   token, meterFilter: { meterName: 'newMeter', label_filters: [] }

--- a/src/hooks/useUsage.tsx
+++ b/src/hooks/useUsage.tsx
@@ -11,7 +11,9 @@ type CustomerPortalMeterLabelFilter =
  * @description
  * A `useUsage` hook allow to fetch and refetch the customer's usage data.
  * @example
- * const { result, loading, error, refetch } = useUsage({ token });
+ * const { result, loading, error, refetch } = useUsage({
+ *   token, meterFilter: { meterName: 'newMeter', label_filters: [] }
+ * });
  */
 export const useUsage = (args?: {
   meterFilter?: CustomerPortalMeterLabelFilter;

--- a/src/hooks/useUsage.tsx
+++ b/src/hooks/useUsage.tsx
@@ -1,0 +1,37 @@
+import { useCallback, useContext } from 'react';
+import { useAsync } from './useAsync';
+import { TokenContext } from './useCustomerToken';
+import { components } from '../apiTypes';
+import getCusomerUsage from '../actions/getUsage';
+
+type CustomerPortalMeterLabelFilter =
+  components['schemas']['CustomerPortalMeterLabelFilter'];
+
+/**
+ * A hook that fetches the customer's usage.
+ */
+export const useUsage = (args?: {
+  meterFilter?: CustomerPortalMeterLabelFilter;
+  token?: string;
+  baseApiUrl?: string;
+}) => {
+  const { token: tokenFromContext } = useContext(TokenContext);
+  const userToken = args?.token || tokenFromContext;
+  const baseApiUrl = args?.baseApiUrl;
+
+  if (!userToken) {
+    throw new Error('Token must be provided.');
+  }
+
+  const fetchFunc = useCallback(
+    (meterFilter?: CustomerPortalMeterLabelFilter) => {
+      if (meterFilter == null) {
+        return Promise.resolve(null);
+      }
+      return getCusomerUsage(userToken, meterFilter, { baseApiUrl });
+    },
+    [userToken, baseApiUrl]
+  );
+
+  return useAsync(fetchFunc, [args?.meterFilter]);
+};

--- a/src/hooks/useUsage.tsx
+++ b/src/hooks/useUsage.tsx
@@ -8,7 +8,10 @@ type CustomerPortalMeterLabelFilter =
   components['schemas']['CustomerPortalMeterLabelFilter'];
 
 /**
- * A hook that fetches the customer's usage.
+ * @description
+ * A `useUsage` hook allow to fetch and refetch the customer's usage data.
+ * @example
+ * const { result, loading, error, refetch } = useUsage({ token });
  */
 export const useUsage = (args?: {
   meterFilter?: CustomerPortalMeterLabelFilter;

--- a/src/hooks/useUsage.tsx
+++ b/src/hooks/useUsage.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useContext } from 'react';
+import { useCallback, useContext, useMemo } from 'react';
 import { useAsync } from './useAsync';
 import { TokenContext } from './useCustomerToken';
 import { components } from '../apiTypes';
-import getCusomerUsage from '../actions/getUsage';
+import getCustomerUsage from '../actions/getUsage';
 
 type CustomerPortalMeterLabelFilter =
   components['schemas']['CustomerPortalMeterLabelFilter'];
@@ -19,19 +19,24 @@ export const useUsage = (args?: {
   const userToken = args?.token || tokenFromContext;
   const baseApiUrl = args?.baseApiUrl;
 
-  if (!userToken) {
-    throw new Error('Token must be provided.');
-  }
+  const initialArgs: [CustomerPortalMeterLabelFilter | undefined] = useMemo(
+    () => [args?.meterFilter],
+    [args?.meterFilter]
+  );
 
   const fetchFn = useCallback(
     (meterFilter?: CustomerPortalMeterLabelFilter) => {
       if (meterFilter == null) {
         return Promise.resolve(null);
       }
-      return getCusomerUsage(userToken, meterFilter, { baseApiUrl });
+      return getCustomerUsage(userToken, meterFilter, { baseApiUrl });
     },
     [userToken, baseApiUrl]
   );
 
-  return useAsync({ fetchFn, initialArgs: [args?.meterFilter] });
+  if (!userToken) {
+    throw new Error('Token must be provided.');
+  }
+
+  return useAsync({ fetchFn, initialArgs });
 };

--- a/src/hooks/useVendorInfo.tsx
+++ b/src/hooks/useVendorInfo.tsx
@@ -24,9 +24,9 @@ export const useVendorInfo = (args?: {
     throw new Error('Token must be provided.');
   }
 
-  const asyncFunc = useCallback(() => {
+  const fetchFn = useCallback(() => {
     return getCustomerVendorInfo(userToken, { baseApiUrl });
   }, [userToken, baseApiUrl]);
 
-  return useAsync(asyncFunc);
+  return useAsync({ fetchFn });
 };

--- a/src/hooks/useVendorInfo.tsx
+++ b/src/hooks/useVendorInfo.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useContext } from 'react';
 import { useAsync } from './useAsync';
-import type { UseAsyncReturnType } from './useAsync';
+import type { UseAsyncFetchReturnType } from './useAsync';
 import { TokenContext } from './useCustomerToken';
 import { components } from '../apiTypes';
 import getCustomerVendorInfo from '../actions/getVendorInfo';
 
 type VendorInfo = components['schemas']['CustomerPortalVendor'];
 
-export type UseVendorInfoReturnType = UseAsyncReturnType<VendorInfo>;
+export type UseVendorInfoReturnType = UseAsyncFetchReturnType<VendorInfo>;
 
 /**
  * A hook that fetches data about the customer's vendor.

--- a/src/hooks/useVendorInfo.tsx
+++ b/src/hooks/useVendorInfo.tsx
@@ -10,7 +10,10 @@ type VendorInfo = components['schemas']['CustomerPortalVendor'];
 export type UseVendorInfoReturnType = UseAsyncFetchReturnType<VendorInfo>;
 
 /**
+ * @description
  * A hook that fetches data about the customer's vendor.
+ * @example
+ * const { result, loading, error, refetch } = useVendorInfo({ token });
  */
 export const useVendorInfo = (args?: {
   token?: string;


### PR DESCRIPTION
**v0.15.0**

This PR brings some new functionality to the hooks. These changes allows refetch the data, using same context. That means that you won't need two state objects to store `activeSubscription` and `updatedSubscription`. There was no good way to use these hooks before.

**New features**
We updated hooks' behavior and now all hooks return a `refetch` function, which allows you to refetch a new data whenever you want, not only during the first render or props changes.

We also updated `useContactInfo` and `useActiveSubscription` hooks with `update` functionality. Using this function you can easily pass a payload and get the updated result from the hook - `result` and `loading` values are updating as expected.

**Deprecations**
Thus we deprecated the following hooks `useUpdateSubscription`, `useCustomerUsage` and `useUpdateContactInfo`. Instead of those you want to you `useActiveSubscription`, `useUsage` and `useContactInfo` hooks.
  