### PR TITLE
fix: set default color-scheme to 'normal' on iframe

### DIFF
--- a/src/components/EmbeddedPortal.tsx
+++ b/src/components/EmbeddedPortal.tsx
@@ -29,7 +29,7 @@ export const EmbeddedPortal = (props: Props) => {
       ref={frameRef}
       src={link}
       {...iframeProps}
-      style={{ ...iframeProps.style, display: 'none' }}
+      style={{ colorScheme: 'normal', ...iframeProps.style, display: 'none' }}
       onLoad={() => {
         if (frameRef.current != null && frameRef.current.style != null) {
           frameRef.current.style.display =


### PR DESCRIPTION
## Why do we need this change?

A browser in dark-mode, will make a transparent background on an iframe white. 

## What changes are in this PR?

Default the iframe style 'color-scheme' to 'normal' so that transparency is maintained on the iframe in both dark/light mode contexts.
