### PR TITLE
Vlad/accrued rev hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octane-components",
-  "version": "0.16.6",
+  "version": "0.17.0",
   "description": "Ready-to-use React components that make it easy to integrate with Octane",
   "author": "Octane (http://getoctane.io)",
   "license": "MIT",

--- a/src/actions/getCustomerDailyAccruedRevenue.ts
+++ b/src/actions/getCustomerDailyAccruedRevenue.ts
@@ -1,0 +1,35 @@
+import { getDailyAccruedRevenue } from '../api/octane';
+import { components } from '../apiTypes';
+
+type CustomerDailyAccruedRevenue =
+  components['schemas']['CustomerPortalDailyAccruedRevenue'];
+
+type Options = {
+  baseApiUrl?: string;
+};
+
+/**
+ * Fetches customer's daily accrued revenue data, or `null` if there is none.
+ */
+export default async function getCustomerDailyAccruedRevenue(
+  customerToken: string,
+  options: Options = {}
+): Promise<CustomerDailyAccruedRevenue[] | null> {
+  if (!customerToken) {
+    throw new Error('Token must be provided.');
+  }
+
+  const response = await getDailyAccruedRevenue({
+    token: customerToken,
+    urlOverride: options.baseApiUrl,
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      "Something went wrong fetching the customer's daily accrued revenue data"
+    );
+  }
+
+  const data = await response.json();
+  return data;
+}

--- a/src/actions/getCustomerTotalAccruedRevenue.ts
+++ b/src/actions/getCustomerTotalAccruedRevenue.ts
@@ -1,0 +1,35 @@
+import { getTotalAccruedRevenue } from '../api/octane';
+import { components } from '../apiTypes';
+
+type CustomerTotalAccruedRevenue =
+  components['schemas']['CustomerPortalAccruedRevenue'];
+
+type Options = {
+  baseApiUrl?: string;
+};
+
+/**
+ * Fetches customer's accrued revenue data, or `null` if there is none.
+ */
+export default async function getCustomerTotalAccruedRevenue(
+  customerToken: string,
+  options: Options = {}
+): Promise<CustomerTotalAccruedRevenue | null> {
+  if (!customerToken) {
+    throw new Error('Token must be provided.');
+  }
+
+  const response = await getTotalAccruedRevenue({
+    token: customerToken,
+    urlOverride: options.baseApiUrl,
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      "Something went wrong fetching the customer's accrued revenue data"
+    );
+  }
+
+  const data = await response.json();
+  return data;
+}

--- a/src/api/octane.ts
+++ b/src/api/octane.ts
@@ -328,3 +328,23 @@ export const getCustomerMeters = makeApiGETEndpoint<
   CustomerPortalMeter[], // Returns the list of customer's meters
   unknown // Undefined failure type
 >(getSelfServeMetersUrl);
+
+export const getTotalAccruedRevenueUrl: UrlFactory = (base = API_BASE) =>
+  `${base}/ecp/total_accrued_revenue`;
+
+export const getTotalAccruedRevenue = makeApiGETEndpoint<
+  never, // No query params
+  [], // No URL path args
+  Schemas['CustomerPortalAccruedRevenue'], // Returns the total accrued revenue broken down by line item
+  unknown // Undefined failure type
+>(getTotalAccruedRevenueUrl);
+
+export const getDailyAccruedRevenueUrl: UrlFactory = (base = API_BASE) =>
+  `${base}/ecp/daily_accrued_revenue`;
+
+export const getDailyAccruedRevenue = makeApiGETEndpoint<
+  never, // No query params
+  [], // No URL path args
+  Schemas['CustomerPortalDailyAccruedRevenue'][], // Returns the daily accrued revenue broken down by line item
+  unknown // Undefined failure type
+>(getDailyAccruedRevenueUrl);

--- a/src/apiTypes.ts
+++ b/src/apiTypes.ts
@@ -497,9 +497,9 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          invoice_id: number;
-          token: string;
           customer_name: string;
+          token: string;
+          invoice_id: number;
         };
       };
       responses: {
@@ -508,9 +508,9 @@ export interface paths {
     };
     parameters: {
       path: {
-        invoice_id: number;
-        token: string;
         customer_name: string;
+        token: string;
+        invoice_id: number;
       };
     };
   };
@@ -519,9 +519,9 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          as_of_str: string;
-          token: string;
           customer_name: string;
+          token: string;
+          as_of_str: string;
         };
       };
       responses: {
@@ -530,9 +530,9 @@ export interface paths {
     };
     parameters: {
       path: {
-        as_of_str: string;
-        token: string;
         customer_name: string;
+        token: string;
+        as_of_str: string;
       };
     };
   };
@@ -617,8 +617,8 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          feature_name: string;
           customer_name: string;
+          feature_name: string;
         };
       };
       responses: {
@@ -633,8 +633,8 @@ export interface paths {
     };
     parameters: {
       path: {
-        feature_name: string;
         customer_name: string;
+        feature_name: string;
       };
     };
   };
@@ -766,17 +766,17 @@ export interface paths {
           customer_name: string;
         };
         query: {
-          /** The number of items to fetch. Defaults to 10. */
-          limit?: number;
-          /** The unique offset to start at when paging forwards */
-          forward_secondary_sort_offset?: string;
-          sort_column?: string;
-          customer_name?: string;
-          status?: string;
           sort_direction?: string;
           /** The sort column offset to start at when paging forwards */
           forward_sort_offset?: string;
+          /** The unique offset to start at when paging forwards */
+          forward_secondary_sort_offset?: string;
+          sort_column?: string;
+          status?: string;
           start_time?: string;
+          customer_name?: string;
+          /** The number of items to fetch. Defaults to 10. */
+          limit?: number;
         };
       };
       responses: {
@@ -879,13 +879,39 @@ export interface paths {
       };
     };
   };
+  '/customers/{customer_name}/credit_top_off_plan/state': {
+    /** Pause/Unpause the immediate charge attempts for a customer's credit top off plan. */
+    put: {
+      parameters: {
+        path: {
+          customer_name: string;
+        };
+      };
+      responses: {
+        /** OK */
+        200: unknown;
+        422: components['responses']['UNPROCESSABLE_ENTITY'];
+        default: components['responses']['DEFAULT_ERROR'];
+      };
+      requestBody: {
+        content: {
+          'application/json': components['schemas']['UpdateCreditTopOffPlanState'];
+        };
+      };
+    };
+    parameters: {
+      path: {
+        customer_name: string;
+      };
+    };
+  };
   '/customers/{customer_name}/usage_across_meters/{token}': {
     /** Get the usage for a customer across all meters in XLS format for a given time period. */
     get: {
       parameters: {
         path: {
-          token: string;
           customer_name: string;
+          token: string;
         };
         query: {
           start_time: string;
@@ -901,8 +927,8 @@ export interface paths {
     };
     parameters: {
       path: {
-        token: string;
         customer_name: string;
+        token: string;
       };
     };
   };
@@ -1437,17 +1463,17 @@ export interface paths {
     get: {
       parameters: {
         query: {
-          /** The number of items to fetch. Defaults to 10. */
-          limit?: number;
-          /** The unique offset to start at when paging forwards */
-          forward_secondary_sort_offset?: string;
-          sort_column?: string;
-          customer_name?: string;
-          status?: string;
           sort_direction?: string;
           /** The sort column offset to start at when paging forwards */
           forward_sort_offset?: string;
+          /** The unique offset to start at when paging forwards */
+          forward_secondary_sort_offset?: string;
+          sort_column?: string;
+          status?: string;
           start_time?: string;
+          customer_name?: string;
+          /** The number of items to fetch. Defaults to 10. */
+          limit?: number;
         };
       };
       responses: {
@@ -1550,8 +1576,8 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          tag: string;
           price_plan_name: string;
+          tag: string;
         };
       };
       responses: {
@@ -1566,8 +1592,8 @@ export interface paths {
     };
     parameters: {
       path: {
-        tag: string;
         price_plan_name: string;
+        tag: string;
       };
     };
   };
@@ -1576,16 +1602,16 @@ export interface paths {
     get: {
       parameters: {
         query: {
-          /** The number of items to fetch. Defaults to 10. */
-          limit?: number;
+          sort_direction?: string;
+          /** The sort column offset to start at when paging forwards */
+          forward_sort_offset?: string;
           /** The unique offset to start at when paging forwards */
           forward_secondary_sort_offset?: string;
           sort_column?: string;
           names?: string[];
-          sort_direction?: string;
           tags?: string[];
-          /** The sort column offset to start at when paging forwards */
-          forward_sort_offset?: string;
+          /** The number of items to fetch. Defaults to 10. */
+          limit?: number;
         };
       };
       responses: {
@@ -1665,8 +1691,8 @@ export interface paths {
     post: {
       parameters: {
         path: {
-          tag: string;
           price_plan_name: string;
+          tag: string;
         };
       };
       responses: {
@@ -1687,8 +1713,8 @@ export interface paths {
     };
     parameters: {
       path: {
-        tag: string;
         price_plan_name: string;
+        tag: string;
       };
     };
   };
@@ -2671,8 +2697,8 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          as_of_str: string;
           customer_name: string;
+          as_of_str: string;
         };
       };
       responses: {
@@ -2687,8 +2713,8 @@ export interface paths {
     };
     parameters: {
       path: {
-        as_of_str: string;
         customer_name: string;
+        as_of_str: string;
       };
     };
   };
@@ -2995,12 +3021,12 @@ export interface components {
     Error: {
       /** Errors */
       errors?: { [key: string]: unknown };
-      /** Error message */
-      message?: string;
-      /** Error name */
-      status?: string;
       /** Error code */
       code?: number;
+      /** Error name */
+      status?: string;
+      /** Error message */
+      message?: string;
     };
     Meter: {
       /** Unique name identifier */
@@ -3014,7 +3040,7 @@ export interface components {
       meter_type: string;
       /** One of `CONTINUOUS`, `DISCRETE`. */
       data_type: string;
-      /** The aggregation applied to the measurement values. One of `MAX`, `SUM`, `TIME_WEIGHTED_SUM`. */
+      /** The aggregation applied to the measurement values. One of `SUM`, `MAX`, `TIME_WEIGHTED_SUM`. */
       aggregation: string;
       /** The reporting unit for the meter */
       unit_name?: string | null;
@@ -3026,13 +3052,7 @@ export interface components {
       primary_labels?: unknown[];
     };
     CreateMeterArgs: {
-      /** Unique name identifier */
-      name?: string;
-      /** Human-friendly name used for display in UI */
-      display_name?: string;
-      /** The unit that the measurement values are reported in. */
-      unit_name?: string;
-      /** COMING SOON: We are replacing meter_type with data_type and aggregation fields to allow more flexible metering. The aggregation type to apply to measurements. One of `MAX`, `SUM`, `TIME_WEIGHTED_SUM`. */
+      /** COMING SOON: We are replacing meter_type with data_type and aggregation fields to allow more flexible metering. The aggregation type to apply to measurements. One of `SUM`, `MAX`, `TIME_WEIGHTED_SUM`. */
       aggregation?:
         | 'SUM'
         | 'MAX'
@@ -3041,44 +3061,50 @@ export interface components {
         | 'COUNT'
         | 'TIME_WEIGHTED_SUM'
         | 'LATEST';
-      /** DEPRECATED: List of expected label keys */
-      expected_labels?: string[];
-      /** List of primary label keys */
-      primary_labels?: string[];
-      /** Type of meter. One of `COUNTER`, `GAUGE` */
-      meter_type?: 'COUNTER' | 'GAUGE';
-      /** Name of the events to associate with this meter. Defaults to meter name. */
-      event_name?: string;
-      /** Whether measurement values are to be considered to be the incremental change or the total. */
-      is_incremental?: boolean;
       /** COMING SOON: We are replacing is_incremental with reporting_method field. Whether measurement values are reporting the incremental change or the total. One of `DELTA`, `TOTAL`. */
       reporting_method?: 'DELTA' | 'TOTAL';
       /** COMING SOON: We are replacing meter_type with data_type and aggregation fields to allow more flexible metering. The type of data represented by the meter. One of `CONTINUOUS`, `DISCRETE`. */
       data_type?: 'CONTINUOUS' | 'DISCRETE';
+      /** Name of the events to associate with this meter. Defaults to meter name. */
+      event_name?: string;
       /** Description of the meter */
       description?: string;
+      /** The unit that the measurement values are reported in. */
+      unit_name?: string;
+      /** List of primary label keys */
+      primary_labels?: string[];
+      /** DEPRECATED: List of expected label keys */
+      expected_labels?: string[];
+      /** Unique name identifier */
+      name?: string;
+      /** Whether measurement values are to be considered to be the incremental change or the total. */
+      is_incremental?: boolean;
+      /** Type of meter. One of `COUNTER`, `GAUGE` */
+      meter_type?: 'COUNTER' | 'GAUGE';
+      /** Human-friendly name used for display in UI */
+      display_name?: string;
     };
     UpdateMeterArgs: {
-      display_name?: string;
       description?: string;
+      display_name?: string;
     };
     Measurement: {
-      /** All times are parsed as `ISO-8601` formatted, UTC-based timestamps */
-      time?: string;
       /** An ID that is unique for the set of labels and meter_name */
       id?: string;
+      /** The raw value of the measurement */
+      value: number;
+      /** The name of the event associated with this measurement. Events allow for a 1 to many relationship between measurement and meters. */
+      event_name?: string;
+      /** A set of key:value label pairs to supplement a measurement. Each meter defines its own set of primary and/or expected labels. */
+      labels?: { [key: string]: string };
+      /** All times are parsed as `ISO-8601` formatted, UTC-based timestamps */
+      time?: string;
       /** Applies to incremental meters and resets the total current value to this new value. */
       reset_total?: boolean;
       /** The name of the customer to associate the measurement with. */
       customer_name?: string;
-      /** A set of key:value label pairs to supplement a measurement. Each meter defines its own set of primary and/or expected labels. */
-      labels?: { [key: string]: string };
-      /** The name of the event associated with this measurement. Events allow for a 1 to many relationship between measurement and meters. */
-      event_name?: string;
       /** The unique name of the meter associated with this measurement */
       meter_name?: string;
-      /** The raw value of the measurement */
-      value: number;
     };
     ContactInfo: {
       address_line_1?: string | null;
@@ -3108,54 +3134,54 @@ export interface components {
       measurement_mappings?: unknown[];
       tags?: components['schemas']['CustomerTag'][];
     };
-    CustomerMeasurementMappingInputArgs: {
-      /** The label key used to map measurements to customers. */
-      label: string;
-      /** A regex used to match the value of the associated label key. */
-      value_regex: string;
-    };
-    CustomerMetadataInput: {
-      property?: string;
-      value?: string | null;
-    };
     ContactInfoInputArgs: {
-      email?: string | null;
-      address_line_1?: string | null;
       state?: string | null;
+      zipcode?: string | null;
       /** List of secondary contact emails (all email communication will also be sent to these emails). */
       secondary_emails?: string[] | null;
       phone?: string | null;
-      country?: string | null;
-      address_line_2?: string | null;
-      logo_url?: string | null;
       vat_id?: string | null;
-      city?: string | null;
-      zipcode?: string | null;
-      url?: string | null;
+      address_line_1?: string | null;
+      logo_url?: string | null;
+      email?: string | null;
       legal_name?: string | null;
+      address_line_2?: string | null;
+      url?: string | null;
+      city?: string | null;
+      country?: string | null;
+    };
+    CustomerMeasurementMappingInputArgs: {
+      /** A regex used to match the value of the associated label key. */
+      value_regex: string;
+      /** The label key used to map measurements to customers. */
+      label: string;
+    };
+    CustomerMetadataInput: {
+      value?: string | null;
+      property?: string;
     };
     CreateCustomerArgs: {
-      name?: string;
-      measurement_mappings?: components['schemas']['CustomerMeasurementMappingInputArgs'][];
-      display_name?: string;
-      customer_metadata?: components['schemas']['CustomerMetadataInput'][];
-      autogenerate_payment_gateway_customer?: boolean;
-      created_at?: string;
-      price_plan_name?: string;
-      autogenerate_accounting_customer?: boolean;
       price_plan_tag?: string;
-      tags?: string[] | null;
       vendor_id?: number;
+      price_plan_name?: string;
+      autogenerate_payment_gateway_customer?: boolean;
       contact_info?: components['schemas']['ContactInfoInputArgs'];
+      autogenerate_accounting_customer?: boolean;
+      measurement_mappings?: components['schemas']['CustomerMeasurementMappingInputArgs'][];
+      created_at?: string;
+      name?: string;
+      customer_metadata?: components['schemas']['CustomerMetadataInput'][];
+      tags?: string[] | null;
+      display_name?: string;
     };
     UpdateCustomerArgs: {
-      name?: string;
-      measurement_mappings?: components['schemas']['CustomerMeasurementMappingInputArgs'][];
-      display_name?: string;
-      created_at?: string;
-      tags?: string[] | null;
       vendor_id?: number;
       contact_info?: components['schemas']['ContactInfoInputArgs'];
+      measurement_mappings?: components['schemas']['CustomerMeasurementMappingInputArgs'][];
+      created_at?: string;
+      name?: string;
+      tags?: string[] | null;
+      display_name?: string;
     };
     CustomerMeasurementMapping: {
       /** The label key used to map measurements to customers. */
@@ -3257,81 +3283,81 @@ export interface components {
       auto_update_stripe_default_payment_method?: boolean | null;
     };
     CustomerBillingSettingsInputArgs: {
-      customer_invoice_detail_level?: string;
-      /** Time length of the grace period between the end of invoice generation and the actual charge. *NOTE*: The specified length is unitless. Unit is designated with the `payment_grace_period_unit` field. */
-      payment_grace_period_length?: number | null;
-      /** Flag that controls whether or not to invoice/charge a true up for a billing cycle on the following invoice. Only applies if invoice_fixed_components_at_start is enabled. */
-      invoice_overages?: boolean | null;
-      /** Time length unit of the grace period between the end of a billing cycle and invoice generation. Must be `day`. */
-      invoice_grace_period_unit?: 'day' | null;
-      /** Optional description attached to the invoice */
-      invoice_memo?: string | null;
-      /** Time length unit of the grace period between the end of invoice generation and actual charge. One of `minute`, `hour`, `day`. */
-      payment_grace_period_unit?: string | null;
-      /** Flag that controls whether to invoice through Octane or through payment provider */
-      invoice_via_octane?: boolean | null;
-      /** Whether newly attached Stripe payment methods should be made the default for customers. */
-      auto_update_stripe_default_payment_method?: boolean | null;
-      /** Account name for ACH/Wire transfer instructions */
-      ach_account_name?: string | null;
+      /** Flag that controls whether to do automated taxes via payment provider */
+      tax_via_payment_provider?: boolean | null;
       /** Flag that controls whether to send receipts for paid invoices. */
       send_receipts?: boolean | null;
+      /** Second line of bank address for ACH/Wire transfer instructions */
+      ach_bank_address_2?: string | null;
+      /** List of days before an invoice is due to communicate upcoming due notices. */
+      upcoming_reminder_days_array?: number[] | null;
       /** Flag that controls whether or not to invoice/charge gauge meters upfront according to their value at start of cycle. Only applies if invoice_fixed_components_at_start is enabled. */
       invoice_metered_components_at_start?: boolean | null;
-      /** Flag that controls the number of retry attempts for invoicing/payments. */
-      retry_attempts?: number | null;
-      /** Flag determining whether ACH/Wire instructions should be included on invoices. */
-      include_ach_instructions?: boolean | null;
-      /** Flag that controls whether to communicate payment failures. */
-      communicate_payment_failures?: boolean | null;
-      /** Time length unit after which to attempt invoice/payment retry. */
-      retry_frequency_unit?: string | null;
-      /** Time length of the grace period between the end of a billing cycle and invoice generation in days. */
-      invoice_grace_period_length?: number | null;
-      /** If set, a minimum charge line item will override any line items that contribute to the minimum (i.e., the minimum charge line item would be the only line item). */
-      should_minimum_charge_override_line_items?: boolean | null;
-      /** Optional url of a custom image to include on invoices. */
-      invoice_logo_url?: string | null;
-      /** List of days after an invoice is due to communicate past due notices. */
-      past_due_reminder_days_array?: number[] | null;
-      /** If using stripe, this field can be used to configure whether invoices should be auto advanced for collection */
-      stripe_auto_advance?: boolean | null;
-      /** The percentage tax rate to apply to invoices. */
-      tax_rate?: number | null;
-      /** Flag that controls whether invoices are auto-approved or require manual approval */
-      auto_approve_invoices?: boolean | null;
-      /** Flag that controls whether or not to auto-charge the customer based on the invoice. */
-      charges_enabled?: boolean | null;
+      /** Whether newly attached Stripe payment methods should be made the default for customers. */
+      auto_update_stripe_default_payment_method?: boolean | null;
+      /** Flag that controls whether or not to invoice/charge the base rate, add ons and other fixed price plan components at the beginning of the billing cycle. */
+      invoice_fixed_components_at_start?: boolean | null;
+      /** Swift code for ACH/Wire transfer instructions */
+      ach_swift_code?: string | null;
+      customer_invoice_detail_level?: string;
       /** If using Stripe, this field can be used to configure whether invoices should be finalized immediately when they are created. */
       stripe_immediate_finalization?: boolean | null;
       /** ABA/Routing number for ACH/Wire transfer instructions */
       ach_routing_number?: string | null;
-      /** Second line of bank address for ACH/Wire transfer instructions */
-      ach_bank_address_2?: string | null;
-      /** Sets the due date on invoices to the number of days after the invoice is sent */
-      days_until_due?: number | null;
-      /** Time length after which to attempt invoice/payment retry. */
-      retry_frequency_length?: number | null;
-      /** True if customer updates should be synced to Stripe. */
-      sync_customer_data_to_payment_gateway?: boolean | null;
-      /** Flag that controls whether to do automated taxes via payment provider */
-      tax_via_payment_provider?: boolean | null;
-      /** List of days before an invoice is due to communicate upcoming due notices. */
-      upcoming_reminder_days_array?: number[] | null;
+      /** Time length unit of the grace period between the end of invoice generation and actual charge. One of `minute`, `hour`, `day`. */
+      payment_grace_period_unit?: string | null;
       /** Bank name for ACH/Wire transfer instructions */
       ach_bank_name?: string | null;
-      /** Swift code for ACH/Wire transfer instructions */
-      ach_swift_code?: string | null;
+      /** Flag determining whether ACH/Wire instructions should be included on invoices. */
+      include_ach_instructions?: boolean | null;
+      /** Flag that controls whether to invoice through Octane or through payment provider */
+      invoice_via_octane?: boolean | null;
+      /** Optional description attached to the invoice */
+      invoice_memo?: string | null;
       /** Flag that controls whether or not invoices should be sent to customers. */
       should_send_invoice_to_customers?: boolean | null;
-      /** Flag that controls whether or not to invoice/charge the base rate, add ons and other fixed price plan components at the beginning of the billing cycle. */
-      invoice_fixed_components_at_start?: boolean | null;
-      /** Default value for whether to align billing cycles to calendar on subscriptions */
-      align_billing_cycles_to_calendar?: boolean | null;
-      /** Account number for ACH/Wire transfer instructions */
-      ach_account_number?: string | null;
+      /** Flag that controls whether invoices are auto-approved or require manual approval */
+      auto_approve_invoices?: boolean | null;
       /** First line of bank address for ACH/Wire transfer instructions */
       ach_bank_address_1?: string | null;
+      /** Optional url of a custom image to include on invoices. */
+      invoice_logo_url?: string | null;
+      /** Account number for ACH/Wire transfer instructions */
+      ach_account_number?: string | null;
+      /** Flag that controls the number of retry attempts for invoicing/payments. */
+      retry_attempts?: number | null;
+      /** Flag that controls whether or not to auto-charge the customer based on the invoice. */
+      charges_enabled?: boolean | null;
+      /** Time length of the grace period between the end of invoice generation and the actual charge. *NOTE*: The specified length is unitless. Unit is designated with the `payment_grace_period_unit` field. */
+      payment_grace_period_length?: number | null;
+      /** Default value for whether to align billing cycles to calendar on subscriptions */
+      align_billing_cycles_to_calendar?: boolean | null;
+      /** Time length unit of the grace period between the end of a billing cycle and invoice generation. Must be `day`. */
+      invoice_grace_period_unit?: 'day' | null;
+      /** List of days after an invoice is due to communicate past due notices. */
+      past_due_reminder_days_array?: number[] | null;
+      /** If set, a minimum charge line item will override any line items that contribute to the minimum (i.e., the minimum charge line item would be the only line item). */
+      should_minimum_charge_override_line_items?: boolean | null;
+      /** True if customer updates should be synced to Stripe. */
+      sync_customer_data_to_payment_gateway?: boolean | null;
+      /** Flag that controls whether to communicate payment failures. */
+      communicate_payment_failures?: boolean | null;
+      /** If using stripe, this field can be used to configure whether invoices should be auto advanced for collection */
+      stripe_auto_advance?: boolean | null;
+      /** The percentage tax rate to apply to invoices. */
+      tax_rate?: number | null;
+      /** Account name for ACH/Wire transfer instructions */
+      ach_account_name?: string | null;
+      /** Sets the due date on invoices to the number of days after the invoice is sent */
+      days_until_due?: number | null;
+      /** Time length of the grace period between the end of a billing cycle and invoice generation in days. */
+      invoice_grace_period_length?: number | null;
+      /** Time length unit after which to attempt invoice/payment retry. */
+      retry_frequency_unit?: string | null;
+      /** Time length after which to attempt invoice/payment retry. */
+      retry_frequency_length?: number | null;
+      /** Flag that controls whether or not to invoice/charge a true up for a billing cycle on the following invoice. Only applies if invoice_fixed_components_at_start is enabled. */
+      invoice_overages?: boolean | null;
     };
     RevenueResponse: {
       revenue?: number;
@@ -3347,36 +3373,29 @@ export interface components {
       limit?: number;
     };
     CustomerFeature: {
-      limit?: number;
       feature_name?: string;
-      enabled?: boolean;
-      quantity?: number;
       label_limits?: components['schemas']['CustomerLabelLimit'][];
+      quantity?: number;
+      enabled?: boolean;
+      limit?: number;
     };
     LineItems: {
-      price_int?: number;
-      quantity_unit?: string;
-      name?: string;
-      end_time?: string;
-      quantity?: number;
+      id?: string;
       metadata?: { [key: string]: string };
+      quantity_unit?: string;
+      description?: string;
+      quantity?: number;
       price?: string;
       start_time?: string;
-      id?: string;
-      description?: string;
+      name?: string;
+      price_int?: number;
+      end_time?: string;
     };
     RevenueBreakdown: {
       total_revenue?: number;
       line_items?: components['schemas']['LineItems'][];
     };
     AccruedRevenueLineItem: {
-      /**
-       * Any extra metadata associated with the item.
-       *         Will include the labels for metered components and metered component minimum charges when applicable
-       */
-      metadata?: { [key: string]: string };
-      /** Accrued revenue for this line item in cents */
-      revenue?: number;
       /**
        * The identifier of the item being returned.
        *         For metered component will be meter name,
@@ -3386,87 +3405,94 @@ export interface components {
        *         for metered component minimum charge will be meter name
        */
       item_identifier?: string;
+      /**
+       * Any extra metadata associated with the item.
+       *         Will include the labels for metered components and metered component minimum charges when applicable
+       */
+      metadata?: { [key: string]: string };
+      /** Accrued revenue for this line item in cents */
+      revenue?: number;
       /** Type of item. One of: METERED_COMPONENT, BASE_PRICE, DISCOUNT, ADD_ON, MINIMUM_CHARGE, METERED_COMPONENT_MINIMUM_CHARGE */
       item_type?: string;
     };
     AccruedRevenue: {
       line_items?: components['schemas']['AccruedRevenueLineItem'][];
-      /** The cycle start of the billing cycle for which the accrued revenue is computed */
-      start_time?: string;
       /** Total accrued revenue for the period in cents */
       total_accrued_revenue?: number;
+      /** The cycle start of the billing cycle for which the accrued revenue is computed */
+      start_time?: string;
       /** The end time within the billing cycle for which this accrued revenue is computed */
       end_time?: string;
     };
     DailyAccruedRevenue: {
+      /** The date for which this accrued revenue is computed */
+      date?: string;
+      /** Total accrued revenue for the day in cents */
+      total_accrued_revenue?: number;
+      /** The start time of the billing cycle for which the accrued revenue is computed */
+      start_time?: string;
       line_items?: components['schemas']['AccruedRevenueLineItem'][];
       /** The end time till when the accrued revenue is computed */
       end_time?: string;
-      /** Total accrued revenue for the day in cents */
-      total_accrued_revenue?: number;
-      /** The date for which this accrued revenue is computed */
-      date?: string;
-      /** The start time of the billing cycle for which the accrued revenue is computed */
-      start_time?: string;
     };
     CustomerMetadata: {
-      /** Property name */
-      property?: string;
       /** Value of property for customer */
       value?: string;
+      /** Property name */
+      property?: string;
     };
     Invoice: {
-      /** Non-empty string if there was an error while sending out invoice */
-      invoicing_error?: string;
-      /** False if not approved */
-      is_approved?: boolean;
-      /** [DEPRECATED] End time of the cycle in which the invoice was generated */
-      end_time?: string;
-      /** The number of retries done to process the payment */
-      payment_retry_attempt?: number;
       /** Tax amount applied to subtotal */
       tax_amount?: number;
+      /** Any discount credits applied to the invoice */
+      discount_credit?: number;
+      /** The potentially permanent state this invoice can live in (e.g., ISSUED if the invoice has been issued to the customer) */
+      status?: string;
+      /** Total amount due */
+      amount_due?: number;
+      pdf_url?: string;
+      /** Non-empty string if there was an error while sending out invoice */
+      invoicing_error?: string;
+      /** False if not paid yet */
+      is_paid?: boolean;
+      /** False if not approved */
+      is_approved?: boolean;
+      /** Non-empty string if there was an error while processing payment */
+      payment_error?: string;
+      /** Amount due before any credits are applied */
+      sub_total?: number;
+      latest_payment_attempt_at?: string;
       /** [DEPRECATED] Start time of the cycle in which the invoice was generated */
       start_time?: string;
       latest_invoice_attempt_at?: string;
       /** Name of the customer this invoice is for. */
       customer_name?: string;
-      /** The potentially permanent state this invoice can live in (e.g., ISSUED if the invoice has been issued to the customer) */
-      status?: string;
-      due_date?: string;
-      /** The number of retries done to send the invoice */
-      invoice_retry_attempt?: number;
-      /** External unique 'uuid' identifier for this Invoice. */
-      id?: string;
-      /** Any discount credits applied to the invoice */
-      discount_credit?: number;
-      latest_payment_attempt_at?: string;
-      /** If there is an error processing this invoice, this field contains the error message. */
-      status_error?: string;
-      /** The date the invoice will be issued to the end customer or forwarded to the payment processor. */
-      issue_date?: string;
-      /** False if not paid yet */
-      is_paid?: boolean;
-      /** The number of the invoice created in the payment processer. */
-      external_invoice_number?: string;
       /** Latest end time of line items covered by the invoice */
       max_item_end_time?: string;
-      /** Amount due before any credits are applied */
-      sub_total?: number;
-      line_items?: components['schemas']['LineItems'][];
+      /** [DEPRECATED] End time of the cycle in which the invoice was generated */
+      end_time?: string;
+      /** The number of the invoice created in the payment processer. */
+      external_invoice_number?: string;
+      /** External unique 'uuid' identifier for this Invoice. */
+      id?: string;
+      /** If there is an error processing this invoice, this field contains the error message. */
+      status_error?: string;
       /** The id of the payment created in the payment processer. */
       external_payment_id?: string;
-      /** Total amount due */
-      amount_due?: number;
-      pdf_url?: string;
-      /** Earliest start time of line items covered by the invoice */
-      min_item_start_time?: string;
+      /** The number of retries done to process the payment */
+      payment_retry_attempt?: number;
       /** False if invoice has not been sent to the customer */
       is_invoiced?: boolean;
       /** The id of the invoice created in the payment processer. */
       external_invoice_id?: string;
-      /** Non-empty string if there was an error while processing payment */
-      payment_error?: string;
+      line_items?: components['schemas']['LineItems'][];
+      /** The date the invoice will be issued to the end customer or forwarded to the payment processor. */
+      issue_date?: string;
+      due_date?: string;
+      /** The number of retries done to send the invoice */
+      invoice_retry_attempt?: number;
+      /** Earliest start time of line items covered by the invoice */
+      min_item_start_time?: string;
     };
     CreditTopOffPlan: {
       /** Unique identifier of this top off plan. */
@@ -3487,36 +3513,40 @@ export interface components {
       charge_immediately?: boolean;
     };
     CreateCreditTopOffPlanInputArgs: {
+      /** Time length unit for the default expiration for credits granted in a top off. */
+      expiration_unit?: string;
       /** Time length of the default expiration for credits granted in a top off. */
       expiration_length?: number;
-      /** Whether to charge the customer immediately when the top off is triggered. */
-      charge_immediately?: boolean;
       /** The threshold in amount of credits at which the balance will be topped off. */
       trigger_amount: number;
-      /** Price for the grant, in lowest denomination (i.e cents). */
-      price: number;
       /** A description that will be used on the invoice line items. */
       description?: string | null;
-      /** Time length unit for the default expiration for credits granted in a top off. */
-      expiration_unit?: string;
       /** Amount of credits that are granted in a single top off. */
       grant_amount: number;
-    };
-    UpdateCreditTopOffPlanInputArgs: {
-      /** Time length of the default expiration for credits granted in a top off. */
-      expiration_length?: number;
+      /** Price for the grant, in lowest denomination (i.e cents). */
+      price: number;
       /** Whether to charge the customer immediately when the top off is triggered. */
       charge_immediately?: boolean;
-      /** The threshold in amount of credits at which the balance will be topped off. */
-      trigger_amount?: number;
-      /** Price for the grant, in lowest denomination (i.e cents). */
-      price?: number;
-      /** A description that will be used on the invoice line items. */
-      description?: string | null;
+    };
+    UpdateCreditTopOffPlanInputArgs: {
       /** Time length unit for the default expiration for credits granted in a top off. */
       expiration_unit?: string;
+      /** Time length of the default expiration for credits granted in a top off. */
+      expiration_length?: number;
+      /** The threshold in amount of credits at which the balance will be topped off. */
+      trigger_amount?: number;
+      /** A description that will be used on the invoice line items. */
+      description?: string | null;
       /** Amount of credits that are granted in a single top off. */
       grant_amount?: number;
+      /** Price for the grant, in lowest denomination (i.e cents). */
+      price?: number;
+      /** Whether to charge the customer immediately when the top off is triggered. */
+      charge_immediately?: boolean;
+    };
+    UpdateCreditTopOffPlanState: {
+      /** True if the top off plan should be paused immediately. False if the top off plan should be unpaused and retry count reset. */
+      pause_immediate_charge_top_off: boolean;
     };
     CustomerSpendThreshold: {
       /** Amount, in cents, for the customer spend threshold. Alerts will be sent when 50, 70, 90, and 100% of this threshold is reached. */
@@ -3531,44 +3561,44 @@ export interface components {
       accounting_customer_id?: string;
     };
     CustomerAvalaraSettings: {
-      /** Tax exemption number specific to this customer */
-      exemption_number?: string;
-      /** Entity code describing this customer. */
-      entity_use_code?: string;
       /** VAT business identification number specific to this customer */
       business_identification_number?: string;
+      /** Entity code describing this customer. */
+      entity_use_code?: string;
+      /** Tax exemption number specific to this customer */
+      exemption_number?: string;
       /** True if Avalara integration should be enabled for this customer, False otherwise. */
       enable_integration?: boolean;
     };
     UpdateCustomerAvalaraSettingsArgs: {
-      /** Tax exemption number specific to this customer */
-      exemption_number?: string;
-      /** Entity code describing this customer. */
-      entity_use_code?: string;
       /** VAT business identification number specific to this customer */
       business_identification_number?: string;
+      /** Entity code describing this customer. */
+      entity_use_code?: string;
+      /** Tax exemption number specific to this customer */
+      exemption_number?: string;
       /** True if Avalara integration should be enabled for this customer, False otherwise. */
       enable_integration?: boolean;
     };
     ValidateAddressResp: {
-      /** Set if 'success' is True. The resolution quality of the geospatial coordinates. */
-      resolution_quality?: string;
-      /** True if validation was successful, False address is invalid. */
-      success?: boolean;
-      /** Set if 'success' is True. Geospatial latitude measurement, in Decimal Degrees (string). */
-      latitude?: string;
       /** Set if 'sucess' is True. Geospatial latitude measurement, in Decimal Degrees (string). */
       longitude?: string;
       /** Set if 'success' is False. Contains the details of why the address is invalid. */
       invalid_address_error?: string;
+      /** True if validation was successful, False address is invalid. */
+      success?: boolean;
+      /** Set if 'success' is True. The resolution quality of the geospatial coordinates. */
+      resolution_quality?: string;
+      /** Set if 'success' is True. Geospatial latitude measurement, in Decimal Degrees (string). */
+      latitude?: string;
     };
     PriceTier: {
       /** Cap of the tier, meaning that any subsequent usage will be bucketed into the following tier. If cap is undefined, it is effectively treated as Infinity. */
       cap?: number;
-      /** The line item description to use if usage falls in this tier. */
-      description?: string;
       /** The price (in lowest currency denomination by which to charge, given that the usage is within the cap range. */
       price: number;
+      /** The line item description to use if usage falls in this tier. */
+      description?: string;
     };
     PriceScheme: {
       display_name?: string | null;
@@ -3748,119 +3778,119 @@ export interface components {
       /** Credit plan associated with this subscription. */
       credit_plan?: components['schemas']['CreditPlan'];
     };
+    FeatureInputArgs: {
+      name: string;
+      description?: string;
+      display_name?: string;
+    };
+    LimitInputArgs: {
+      limit?: number;
+      feature: components['schemas']['FeatureInputArgs'];
+    };
     DiscountInputArgs: {
-      /** Offset, in number of billing cycles, for when this discount will apply. If set to 0, the discount will start applying from the current billing cycle. If set to 1, the discount will start applying from the next billing cycle, etc. For scheduled subscriptions, the offset starts from the initial billing cycle. */
-      billing_cycle_start_offset?: number;
-      /** For METERED_COMPONENT scoped discounts: the UUID of the metered component that the discount covers. */
-      metered_component_uuid?: string;
-      /** For METERED_COMPONENT scoped discounts: Dictionary of labels (key: value) that the discount covers. The entire set of labels must be provided. */
-      labels?: { [key: string]: string };
       amount?: number;
       /** For ADD_ON scoped discounts: the name of the add on that the discount covers. */
       add_on_name?: string;
-      /** The scope that this discount covers. One of 'INVOICE_TOTAL', 'ADD_ON', 'METERED_COMPONENT'. */
-      scope?: 'INVOICE_TOTAL' | 'ADD_ON' | 'METERED_COMPONENT';
-      discount_type?: 'FLAT' | 'PERCENT';
+      /** For METERED_COMPONENT scoped discounts: Dictionary of labels (key: value) that the discount covers. The entire set of labels must be provided. */
+      labels?: { [key: string]: string };
       /** Length, in billing cycles, that this discount will be active. */
       billing_cycle_duration?: number;
-    };
-    TrialInputArgs: {
-      credit?: number;
-      time_length?: number;
-      time_unit_name?: string;
-    };
-    FeatureInputArgs: {
-      name: string;
-      display_name?: string;
-      description?: string;
-    };
-    LimitInputArgs: {
-      feature: components['schemas']['FeatureInputArgs'];
-      limit?: number;
-    };
-    CreditPlanInputArgs: {
-      /** Interval, in billing cycles, between each credit grant. Null for single grant plans. */
-      interval_between_grants?: number;
-      /** Billing cycles between payments. Null for grants paid in a single payment. If this plan has recurring grants (i.e `interval_between_grants` is not null), then this field must be a factor of `interval_between_grants`. */
-      interval_between_payments?: number;
-      /** Duration length before each credit grant expires. Null for no expiration. */
-      grant_expiration_length?: number;
-      /** How many payments each credit grant will have. Defaults to 1 for single payment grants. If this plan has has recurring grants (i.e `interval_between_grants` is not null), then this field must be a factor of `interval_between_grants`. */
-      payments_per_grant?: number;
-      /** Amount of credits that are granted in a single grant. */
-      amount: number;
-      /** Price for the grant, in lowest denomination (i.e cents). Defaults to $1 (100 cents) per credit if not specified */
-      price?: number;
-      /** Duration unit before each credit grant expires. Null for no expiration. */
-      grant_expiration_unit?: string;
-      /** A description that will be used on the invoice line items. */
-      description?: string;
+      /** The scope that this discount covers. One of 'INVOICE_TOTAL', 'ADD_ON', 'METERED_COMPONENT'. */
+      scope?: 'INVOICE_TOTAL' | 'ADD_ON' | 'METERED_COMPONENT';
+      /** Offset, in number of billing cycles, for when this discount will apply. If set to 0, the discount will start applying from the current billing cycle. If set to 1, the discount will start applying from the next billing cycle, etc. For scheduled subscriptions, the offset starts from the initial billing cycle. */
+      billing_cycle_start_offset?: number;
+      discount_type?: 'FLAT' | 'PERCENT';
+      /** For METERED_COMPONENT scoped discounts: the UUID of the metered component that the discount covers. */
+      metered_component_uuid?: string;
     };
     SubscriptionAddOnInput: {
       quantity?: number;
-      name: string;
       /** Override for the add-on price on this subscription. */
       price?: number;
+      name: string;
+    };
+    TrialInputArgs: {
+      credit?: number;
+      time_unit_name?: string;
+      time_length?: number;
+    };
+    CreditPlanInputArgs: {
+      /** Amount of credits that are granted in a single grant. */
+      amount: number;
+      /** Duration unit before each credit grant expires. Null for no expiration. */
+      grant_expiration_unit?: string;
+      /** Interval, in billing cycles, between each credit grant. Null for single grant plans. */
+      interval_between_grants?: number;
+      /** A description that will be used on the invoice line items. */
+      description?: string;
+      /** Duration length before each credit grant expires. Null for no expiration. */
+      grant_expiration_length?: number;
+      /** Price for the grant, in lowest denomination (i.e cents). Defaults to $1 (100 cents) per credit if not specified */
+      price?: number;
+      /** How many payments each credit grant will have. Defaults to 1 for single payment grants. If this plan has has recurring grants (i.e `interval_between_grants` is not null), then this field must be a factor of `interval_between_grants`. */
+      payments_per_grant?: number;
+      /** Billing cycles between payments. Null for grants paid in a single payment. If this plan has recurring grants (i.e `interval_between_grants` is not null), then this field must be a factor of `interval_between_grants`. */
+      interval_between_payments?: number;
     };
     CreateSubscriptionArgs: {
-      discounts?: components['schemas']['DiscountInputArgs'][];
-      /** DEPRECATED - use discounts field */
-      discount_override?: components['schemas']['DiscountInputArgs'];
-      trial_override?: components['schemas']['TrialInputArgs'];
-      coupon_override_name?: string;
-      limits_override?: components['schemas']['LimitInputArgs'][];
-      /** The name of the price plan to subscribe customer to. Either provide price plan UUID or name/tag but not both. */
-      price_plan_name?: string;
-      /** Credit plan associated with this subscription. */
-      credit_plan?: components['schemas']['CreditPlanInputArgs'];
       /** The tag of the specific price plan version for the given price_plan_name. Should only be set if identifying price plan by name. */
       price_plan_tag?: string;
+      limits_override?: components['schemas']['LimitInputArgs'][];
+      /** DEPRECATED - use discounts field */
+      discount_override?: components['schemas']['DiscountInputArgs'];
       /** The UUID of the specific price plan version to subscribe customer to. Either provide price plan UUID or name/tag but not both. */
       price_plan_uuid?: string;
       /** Whether to align this subscripton's billing cycles to calendar boundaries (e.g., begining of every month). If the subscripiton is effective as of the middle of the month, the first cycle will be prorated appropriately. */
       align_to_calendar?: boolean;
-      features_override?: components['schemas']['FeatureInputArgs'][];
       add_ons?: components['schemas']['SubscriptionAddOnInput'][];
+      coupon_override_name?: string;
+      trial_override?: components['schemas']['TrialInputArgs'];
+      discounts?: components['schemas']['DiscountInputArgs'][];
+      /** Credit plan associated with this subscription. */
+      credit_plan?: components['schemas']['CreditPlanInputArgs'];
+      /** The name of the price plan to subscribe customer to. Either provide price plan UUID or name/tag but not both. */
+      price_plan_name?: string;
+      features_override?: components['schemas']['FeatureInputArgs'][];
       effective_at?: string;
     };
     UpdateSubscriptionArgs: {
-      discounts?: components['schemas']['DiscountInputArgs'][];
       /** Boolean that indicates whether to update the subscription at the start of the billing cycle. If 'true' and either of `effective_at` or `at_cycle_end` are set, will return an error. */
       at_cycle_start?: boolean;
-      /** DEPRECATED - use discounts field */
-      discount_override?: components['schemas']['DiscountInputArgs'] | null;
-      trial_override?: components['schemas']['TrialInputArgs'] | null;
-      coupon_override_name?: string;
-      limits_override?: components['schemas']['LimitInputArgs'][] | null;
-      /** The name of the price plan to subscribe customer to. Either provide price plan UUID or name/tag but not both. */
-      price_plan_name?: string;
-      /** Credit plan associated with this subscription. */
-      credit_plan?: components['schemas']['CreditPlanInputArgs'];
       /** The tag of the specific price plan version for the given price_plan_name. Should only be set if identifying price plan by name. */
       price_plan_tag?: string;
+      limits_override?: components['schemas']['LimitInputArgs'][] | null;
+      /** DEPRECATED - use discounts field */
+      discount_override?: components['schemas']['DiscountInputArgs'] | null;
       /** The UUID of the specific price plan version to subscribe customer to. Either provide price plan UUID or name/tag but not both. */
       price_plan_uuid?: string;
       /** Whether to align this subscripton's billing cycles to calendar boundaries (e.g., begining of every month). If the subscripiton is effective as of the middle of the month, the first cycle will be prorated appropriately. */
       align_to_calendar?: boolean;
+      add_ons?: components['schemas']['SubscriptionAddOnInput'][] | null;
+      coupon_override_name?: string;
+      trial_override?: components['schemas']['TrialInputArgs'] | null;
+      discounts?: components['schemas']['DiscountInputArgs'][];
+      /** Credit plan associated with this subscription. */
+      credit_plan?: components['schemas']['CreditPlanInputArgs'];
+      /** The name of the price plan to subscribe customer to. Either provide price plan UUID or name/tag but not both. */
+      price_plan_name?: string;
       features_override?: components['schemas']['FeatureInputArgs'][] | null;
       /** Boolean that indicates whether to update the subscription at the end of the billing cycle. If 'true' and either of `effective_at` or `at_cycle_start` are set, will return an error. */
       at_cycle_end?: boolean;
-      add_ons?: components['schemas']['SubscriptionAddOnInput'][] | null;
       effective_at?: string;
     };
     DeleteSubscriptionArgs: {
       /** Boolean that indicates whether to expire the subscription at the end of thebilling cycle. If 'true' and `expire_at` is set, will return an error. */
       at_cycle_end?: boolean;
+      vendor_id?: number;
       expire_at?: string;
       customer_id?: number;
-      vendor_id?: number;
     };
     UpdateSubscriptionInPlaceArgs: {
+      add_ons?: components['schemas']['SubscriptionAddOnInput'][] | null;
       /** DEPRECATED - use discounts field */
       discount_override?: components['schemas']['DiscountInputArgs'] | null;
-      discounts?: components['schemas']['DiscountInputArgs'][];
       coupon_override_name?: string;
-      add_ons?: components['schemas']['SubscriptionAddOnInput'][] | null;
+      discounts?: components['schemas']['DiscountInputArgs'][];
     };
     BillingCycleDate: {
       cycle_end: string;
@@ -3907,10 +3937,10 @@ export interface components {
       effective_at?: string;
     };
     DeleteDiscountInputArgs: {
-      /** External UUID representing the discount to be deleted. */
-      discount_uuid: string;
       /** Number of billing cycles that the discount should expire in. Defaults to 0 (start of current billing cycle). If the inputted discount is scheduled, it is the number of billing cycles relative to the scheduled start. You can only shorten a discount, it is not possible to extend it. */
       billing_cycle_duration?: number;
+      /** External UUID representing the discount to be deleted. */
+      discount_uuid: string;
     };
     UpdateInvoiceStatusArgs: {
       /** The target status of the invoice. Valid values are INVOICE_PAID and INVOICE_VOIDED. Default is INVOICE_PAID if no status is provided. */
@@ -3918,50 +3948,29 @@ export interface components {
     };
     PastInvoice: {
       status_description?: string;
-      customer_name?: string;
       issue_date?: string;
-      amount_due?: number;
-      status?: string;
-      due_date?: string;
-      export_url?: string;
       /** External unique 'uuid' identifier for this Invoice. */
       id?: string;
+      due_date?: string;
+      status?: string;
+      export_url?: string;
+      customer_name?: string;
+      amount_due?: number;
     };
     PastInvoices: {
-      /** The number of items to fetch. Defaults to 10. */
-      limit?: number;
+      sort_direction?: string;
+      /** The sort column offset to start at when paging forwards */
+      forward_sort_offset?: string;
       /** The unique offset to start at when paging forwards */
       forward_secondary_sort_offset?: string;
       sort_column?: string;
-      sort_direction?: string;
       invoices?: components['schemas']['PastInvoice'][];
-      /** The sort column offset to start at when paging forwards */
-      forward_sort_offset?: string;
+      /** The number of items to fetch. Defaults to 10. */
+      limit?: number;
     };
     CreateRetryArgs: { [key: string]: unknown };
     Retry: {
       success?: boolean;
-    };
-    PriceInputArgs: {
-      cap?: number;
-      description?: string;
-      price?: number;
-    };
-    PriceSchemeInputArgs: {
-      /** One of 'FLAT', 'TIERED', or 'STAIRSTEP' */
-      scheme_type: string;
-      /** The name of the unit used for this metered component (e.g., gigabyte) */
-      unit_name?: string;
-      /** The time unit for the metered component (e.g., month or hour) */
-      time_unit_name?: string;
-      /** Array of (key, value) meter labels to price on & the price tiers that should be used against those labels */
-      price_list?: { [key: string]: unknown }[];
-      /** The % increase/decrease in price after the minimum charge is reached (e.g., 25.5 -> 25.5% increase). */
-      post_minimum_charge_percentage_change?: number;
-      /** Array of price tiers, each of which consists of `price` and `cap` key:value pairs */
-      prices?: components['schemas']['PriceInputArgs'][];
-      /** Size of the unit batch to use for the prices. Can only be set if scheme_type='FLAT' or 'TIERED'. E.g. To charge $10 per 100 API Requests, set batch_size to 100. */
-      batch_size?: number;
     };
     MeteredComponentLabelLimitInputArgs: {
       /** Dictionary of labels (key: value) to which the limit applies. A value of 'any' will apply the limit to any single value of the field. */
@@ -3969,124 +3978,145 @@ export interface components {
       /** Numeric limit to set on customer usage for the meter with the given labels. */
       limit: number;
     };
+    PriceInputArgs: {
+      cap?: number;
+      price?: number;
+      description?: string;
+    };
+    PriceSchemeInputArgs: {
+      /** Array of price tiers, each of which consists of `price` and `cap` key:value pairs */
+      prices?: components['schemas']['PriceInputArgs'][];
+      /** Size of the unit batch to use for the prices. Can only be set if scheme_type='FLAT' or 'TIERED'. E.g. To charge $10 per 100 API Requests, set batch_size to 100. */
+      batch_size?: number;
+      /** Array of (key, value) meter labels to price on & the price tiers that should be used against those labels */
+      price_list?: { [key: string]: unknown }[];
+      /** The % increase/decrease in price after the minimum charge is reached (e.g., 25.5 -> 25.5% increase). */
+      post_minimum_charge_percentage_change?: number;
+      /** The name of the unit used for this metered component (e.g., gigabyte) */
+      unit_name?: string;
+      /** The time unit for the metered component (e.g., month or hour) */
+      time_unit_name?: string;
+      /** One of 'FLAT', 'TIERED', or 'STAIRSTEP' */
+      scheme_type: string;
+    };
     MeteredComponentInputArgs: {
-      price_scheme?: components['schemas']['PriceSchemeInputArgs'];
-      /** Numeric limit to set on customer usage for the meter. */
-      limit?: number;
-      /** Name to be used on invoice. */
-      display_name?: string;
-      /** Codename of the meter. */
-      meter_name?: string;
-      meter_id?: number;
-      /** Minimum charge for the metered component */
-      minimum_charge?: number | null;
-      label_limits?: components['schemas']['MeteredComponentLabelLimitInputArgs'][];
       /** Minimum charge frequency (as a multiple of the price plan period) for the metered component */
       minimum_charge_frequency?: number | null;
+      meter_id?: number;
+      id?: number;
       /** Watermark value under which the meter should not be charged. Only applicable to meters with 'time_weighted' aggregation. */
       watermark?: number;
-      id?: number;
+      label_limits?: components['schemas']['MeteredComponentLabelLimitInputArgs'][];
+      /** Minimum charge for the metered component */
+      minimum_charge?: number | null;
+      /** Numeric limit to set on customer usage for the meter. */
+      limit?: number;
+      price_scheme?: components['schemas']['PriceSchemeInputArgs'];
+      /** Codename of the meter. */
+      meter_name?: string;
+      /** Name to be used on invoice. */
+      display_name?: string;
     };
     PriceInputArgs1: {
       /** The cap for which the price applies until. If not set, the price always applies. */
       cap?: number;
-      /** Optional description. */
-      description?: string;
       /** The price for the tier. */
       price?: number;
-    };
-    AddOnInputArgs: {
-      /** One of 'FLAT', 'TIERED' */
-      price_scheme_type?: 'FLAT' | 'TIERED';
-      limit?: number;
-      /** Whether this add on can only be used & charged once. */
-      single_use?: boolean;
-      /** The frequency at which to charge this add on. Currently the only values supported are price_frequency or 1. */
-      charge_frequency?: number;
-      feature: components['schemas']['FeatureInputArgs'];
-      /** The frequency at which to price this add on. */
-      price_frequency?: number;
-      quantity_enabled?: boolean;
-      /** DEPRECATED. Use price_scheme_type and prices instead. */
-      price?: number;
-      /** Array of price tiers, each of which consists of `price` and `cap` key:value pairs */
-      prices?: components['schemas']['PriceInputArgs1'][];
-      /** This field indicates whether or not we should cut an invoice immediately upon attaching this add on to a price plan. */
-      immediately_charge?: boolean;
-    };
-    CreatePricePlanArgs: {
-      name?: string;
-      display_name?: string;
-      /** The frequency (as a an integer multiple of the period) at which to charge the base price. */
-      base_price_frequency?: number;
-      base_price?: number;
-      features?: components['schemas']['FeatureInputArgs'][];
-      trial?: components['schemas']['TrialInputArgs'];
-      /** Minimum amount (in cents) to charge every price plan period. */
-      minimum_charge?: number | null;
-      limits?: components['schemas']['LimitInputArgs'][];
-      metered_components?: components['schemas']['MeteredComponentInputArgs'][];
-      tags?: string[];
-      period?: string;
-      vendor_id?: number;
-      /** Custom invoice description for the base price line item. */
-      base_price_description?: string | null;
-      add_ons?: components['schemas']['AddOnInputArgs'][];
-      /** The frequency (as a an integer multiple of the period) at which to charge the minimum charge. */
-      minimum_charge_frequency?: number | null;
+      /** Optional description. */
       description?: string;
     };
-    ListPricePlans: {
-      /** The number of items to fetch. Defaults to 10. */
+    AddOnInputArgs: {
+      /** Array of price tiers, each of which consists of `price` and `cap` key:value pairs */
+      prices?: components['schemas']['PriceInputArgs1'][];
+      quantity_enabled?: boolean;
+      /** This field indicates whether or not we should cut an invoice immediately upon attaching this add on to a price plan. */
+      immediately_charge?: boolean;
+      /** The frequency at which to price this add on. */
+      price_frequency?: number;
+      feature: components['schemas']['FeatureInputArgs'];
+      /** Whether this add on can only be used & charged once. */
+      single_use?: boolean;
+      /** One of 'FLAT', 'TIERED' */
+      price_scheme_type?: 'FLAT' | 'TIERED';
+      /** DEPRECATED. Use price_scheme_type and prices instead. */
+      price?: number;
+      /** The frequency at which to charge this add on. Currently the only values supported are price_frequency or 1. */
+      charge_frequency?: number;
       limit?: number;
+    };
+    CreatePricePlanArgs: {
+      vendor_id?: number;
+      period?: string;
+      metered_components?: components['schemas']['MeteredComponentInputArgs'][];
+      add_ons?: components['schemas']['AddOnInputArgs'][];
+      description?: string;
+      /** The frequency (as a an integer multiple of the period) at which to charge the base price. */
+      base_price_frequency?: number;
+      trial?: components['schemas']['TrialInputArgs'];
+      base_price?: number;
+      /** Custom invoice description for the base price line item. */
+      base_price_description?: string | null;
+      limits?: components['schemas']['LimitInputArgs'][];
+      name?: string;
+      /** Minimum amount (in cents) to charge every price plan period. */
+      minimum_charge?: number | null;
+      tags?: string[];
+      features?: components['schemas']['FeatureInputArgs'][];
+      /** The frequency (as a an integer multiple of the period) at which to charge the minimum charge. */
+      minimum_charge_frequency?: number | null;
+      display_name?: string;
+    };
+    ListPricePlans: {
+      sort_direction?: string;
+      /** The sort column offset to start at when paging forwards */
+      forward_sort_offset?: string;
       /** The unique offset to start at when paging forwards */
       forward_secondary_sort_offset?: string;
       sort_column?: string;
-      sort_direction?: string;
       price_plans?: components['schemas']['PricePlan'][];
-      /** The sort column offset to start at when paging forwards */
-      forward_sort_offset?: string;
+      /** The number of items to fetch. Defaults to 10. */
+      limit?: number;
     };
     UpdatePricePlanArgs: {
-      name?: string;
-      display_name?: string;
+      vendor_id?: number;
+      period?: string;
+      metered_components?: components['schemas']['MeteredComponentInputArgs'][];
+      add_ons?: components['schemas']['AddOnInputArgs'][];
+      description?: string;
       /** The frequency (as a an integer multiple of the period) at which to charge the base price. */
       base_price_frequency?: number;
-      base_price?: number;
-      features?: components['schemas']['FeatureInputArgs'][];
       trial?: components['schemas']['TrialInputArgs'];
+      base_price?: number;
+      /** Custom invoice description for the base price line item. */
+      base_price_description?: string | null;
+      limits?: components['schemas']['LimitInputArgs'][];
+      name?: string;
       /** Minimum amount (in cents) to charge every price plan period. */
       minimum_charge?: number | null;
-      limits?: components['schemas']['LimitInputArgs'][];
-      metered_components?: components['schemas']['MeteredComponentInputArgs'][];
       tags?: string[];
-      period?: string;
-      vendor_id?: number;
-      /** Custom invoice description for the base price line item. */
-      base_price_description?: string | null;
-      add_ons?: components['schemas']['AddOnInputArgs'][];
+      features?: components['schemas']['FeatureInputArgs'][];
       /** The frequency (as a an integer multiple of the period) at which to charge the minimum charge. */
       minimum_charge_frequency?: number | null;
-      description?: string;
+      display_name?: string;
     };
     UpdatePricePlanInPlaceArgs: {
-      display_name?: string;
-      features?: components['schemas']['FeatureInputArgs'][];
-      limits?: components['schemas']['LimitInputArgs'][];
       metered_components?: components['schemas']['MeteredComponentInputArgs'][];
-      /** Custom invoice description for the base price line item. */
-      base_price_description?: string | null;
       add_ons?: components['schemas']['AddOnInputArgs'][];
       description?: string;
+      /** Custom invoice description for the base price line item. */
+      base_price_description?: string | null;
+      limits?: components['schemas']['LimitInputArgs'][];
+      features?: components['schemas']['FeatureInputArgs'][];
+      display_name?: string;
     };
     SelfServePricePlansInputArgs: {
       price_plan_uuids?: string[];
     };
     AddFeaturesToPricePlanInput: {
-      /** List of new features to add */
-      features?: components['schemas']['FeatureInputArgs'][];
       /** List of new limits to add */
       limits?: components['schemas']['LimitInputArgs'][];
+      /** List of new features to add */
+      features?: components['schemas']['FeatureInputArgs'][];
     };
     RemoveFeaturesFromPricePlanInput: {
       /** List of feature names to remove */
@@ -4101,9 +4131,9 @@ export interface components {
       metered_components: components['schemas']['MeteredComponentInputArgs'][];
     };
     UpdateMeteredComponentLimitsInput: {
-      label_limits?: components['schemas']['MeteredComponentLabelLimitInputArgs'][];
       /** Numeric limit to set on customer usage for the meter. */
       limit?: number | null;
+      label_limits?: components['schemas']['MeteredComponentLabelLimitInputArgs'][];
     };
     PaymentGatewayCredentialInputArgs: {
       auth_token?: string;
@@ -4111,158 +4141,158 @@ export interface components {
       account_id?: string;
     };
     CreateBillingSettingsInputArgs: {
-      customer_invoice_detail_level?: string;
-      /** Time length of the grace period between the end of invoice generation and the actual charge. *NOTE*: The specified length is unitless. Unit is designated with the `payment_grace_period_unit` field. */
-      payment_grace_period_length?: number;
-      /** Flag that controls whether or not to invoice/charge a true up for a billing cycle on the following invoice. Only applies if invoice_fixed_components_at_start is enabled. */
-      invoice_overages?: boolean;
-      /** Time length unit of the grace period between the end of a billing cycle and invoice generation. Must be `day`. */
-      invoice_grace_period_unit?: 'day';
-      /** Optional description attached to the invoice */
-      invoice_memo?: string | null;
-      /** Time length unit of the grace period between the end of invoice generation and actual charge. One of `minute`, `hour`, `day`. */
-      payment_grace_period_unit?: string;
-      /** Flag that controls whether to invoice through Octane or through payment provider */
-      invoice_via_octane?: boolean;
-      /** Whether newly attached Stripe payment methods should be made the default for customers. */
-      auto_update_stripe_default_payment_method?: boolean | null;
-      /** Account name for ACH/Wire transfer instructions */
-      ach_account_name?: string | null;
+      /** Flag that controls whether to do automated taxes via payment provider */
+      tax_via_payment_provider?: boolean;
       /** Flag that controls whether to send receipts for paid invoices. */
       send_receipts?: boolean | null;
+      /** Second line of bank address for ACH/Wire transfer instructions */
+      ach_bank_address_2?: string | null;
+      /** List of days before an invoice is due to communicate upcoming due notices. */
+      upcoming_reminder_days_array?: number[] | null;
       /** Flag that controls whether or not to invoice/charge gauge meters upfront according to their value at start of cycle. Only applies if invoice_fixed_components_at_start is enabled. */
       invoice_metered_components_at_start?: boolean;
-      /** Flag that controls the number of retry attempts for invoicing/payments. */
-      retry_attempts?: number;
-      /** Flag determining whether ACH/Wire instructions should be included on invoices. */
-      include_ach_instructions?: boolean | null;
-      /** Flag that controls whether to communicate payment failures. */
-      communicate_payment_failures?: boolean | null;
-      /** Time length unit after which to attempt invoice/payment retry. */
-      retry_frequency_unit?: string;
-      /** Time length of the grace period between the end of a billing cycle and invoice generation in days. */
-      invoice_grace_period_length?: number;
-      /** If set, a minimum charge line item will override any line items that contribute to the minimum (i.e., the minimum charge line item would be the only line item). */
-      should_minimum_charge_override_line_items?: boolean | null;
-      /** Optional url of a custom image to include on invoices. */
-      invoice_logo_url?: string | null;
-      /** List of days after an invoice is due to communicate past due notices. */
-      past_due_reminder_days_array?: number[] | null;
-      /** If using stripe, this field can be used to configure whether invoices should be auto advanced for collection */
-      stripe_auto_advance?: boolean;
-      /** The percentage tax rate to apply to invoices. */
-      tax_rate?: number | null;
-      /** Flag that controls whether invoices are auto-approved or require manual approval */
-      auto_approve_invoices?: boolean;
-      /** Flag that controls whether or not to auto-charge the customer based on the invoice. */
-      charges_enabled?: boolean;
+      /** Whether newly attached Stripe payment methods should be made the default for customers. */
+      auto_update_stripe_default_payment_method?: boolean | null;
+      /** Flag that controls whether or not to invoice/charge the base rate, add ons and other fixed price plan components at the beginning of the billing cycle. */
+      invoice_fixed_components_at_start?: boolean;
+      /** Swift code for ACH/Wire transfer instructions */
+      ach_swift_code?: string | null;
+      customer_invoice_detail_level?: string;
       /** If using Stripe, this field can be used to configure whether invoices should be finalized immediately when they are created. */
       stripe_immediate_finalization?: boolean | null;
       /** ABA/Routing number for ACH/Wire transfer instructions */
       ach_routing_number?: string | null;
-      /** Second line of bank address for ACH/Wire transfer instructions */
-      ach_bank_address_2?: string | null;
-      /** Sets the due date on invoices to the number of days after the invoice is sent */
-      days_until_due?: number | null;
-      /** Time length after which to attempt invoice/payment retry. */
-      retry_frequency_length?: number;
-      /** True if customer updates should be synced to Stripe. */
-      sync_customer_data_to_payment_gateway?: boolean | null;
-      /** Flag that controls whether to do automated taxes via payment provider */
-      tax_via_payment_provider?: boolean;
-      /** List of days before an invoice is due to communicate upcoming due notices. */
-      upcoming_reminder_days_array?: number[] | null;
+      /** Time length unit of the grace period between the end of invoice generation and actual charge. One of `minute`, `hour`, `day`. */
+      payment_grace_period_unit?: string;
       /** Bank name for ACH/Wire transfer instructions */
       ach_bank_name?: string | null;
-      /** Swift code for ACH/Wire transfer instructions */
-      ach_swift_code?: string | null;
+      /** Flag determining whether ACH/Wire instructions should be included on invoices. */
+      include_ach_instructions?: boolean | null;
+      /** Flag that controls whether to invoice through Octane or through payment provider */
+      invoice_via_octane?: boolean;
+      /** Optional description attached to the invoice */
+      invoice_memo?: string | null;
       /** Flag that controls whether or not invoices should be sent to customers. */
       should_send_invoice_to_customers?: boolean;
-      /** Flag that controls whether or not to invoice/charge the base rate, add ons and other fixed price plan components at the beginning of the billing cycle. */
-      invoice_fixed_components_at_start?: boolean;
-      /** Default value for whether to align billing cycles to calendar on subscriptions */
-      align_billing_cycles_to_calendar?: boolean;
-      /** Account number for ACH/Wire transfer instructions */
-      ach_account_number?: string | null;
+      /** Flag that controls whether invoices are auto-approved or require manual approval */
+      auto_approve_invoices?: boolean;
       /** First line of bank address for ACH/Wire transfer instructions */
       ach_bank_address_1?: string | null;
+      /** Optional url of a custom image to include on invoices. */
+      invoice_logo_url?: string | null;
+      /** Account number for ACH/Wire transfer instructions */
+      ach_account_number?: string | null;
+      /** Flag that controls the number of retry attempts for invoicing/payments. */
+      retry_attempts?: number;
+      /** Flag that controls whether or not to auto-charge the customer based on the invoice. */
+      charges_enabled?: boolean;
+      /** Time length of the grace period between the end of invoice generation and the actual charge. *NOTE*: The specified length is unitless. Unit is designated with the `payment_grace_period_unit` field. */
+      payment_grace_period_length?: number;
+      /** Default value for whether to align billing cycles to calendar on subscriptions */
+      align_billing_cycles_to_calendar?: boolean;
+      /** Time length unit of the grace period between the end of a billing cycle and invoice generation. Must be `day`. */
+      invoice_grace_period_unit?: 'day';
+      /** List of days after an invoice is due to communicate past due notices. */
+      past_due_reminder_days_array?: number[] | null;
+      /** If set, a minimum charge line item will override any line items that contribute to the minimum (i.e., the minimum charge line item would be the only line item). */
+      should_minimum_charge_override_line_items?: boolean | null;
+      /** True if customer updates should be synced to Stripe. */
+      sync_customer_data_to_payment_gateway?: boolean | null;
+      /** Flag that controls whether to communicate payment failures. */
+      communicate_payment_failures?: boolean | null;
+      /** If using stripe, this field can be used to configure whether invoices should be auto advanced for collection */
+      stripe_auto_advance?: boolean;
+      /** The percentage tax rate to apply to invoices. */
+      tax_rate?: number | null;
+      /** Account name for ACH/Wire transfer instructions */
+      ach_account_name?: string | null;
+      /** Sets the due date on invoices to the number of days after the invoice is sent */
+      days_until_due?: number | null;
+      /** Time length of the grace period between the end of a billing cycle and invoice generation in days. */
+      invoice_grace_period_length?: number;
+      /** Time length unit after which to attempt invoice/payment retry. */
+      retry_frequency_unit?: string;
+      /** Time length after which to attempt invoice/payment retry. */
+      retry_frequency_length?: number;
+      /** Flag that controls whether or not to invoice/charge a true up for a billing cycle on the following invoice. Only applies if invoice_fixed_components_at_start is enabled. */
+      invoice_overages?: boolean;
     };
     UpdateBillingSettingsInputArgs: {
-      customer_invoice_detail_level?: string;
-      /** Time length of the grace period between the end of invoice generation and the actual charge. *NOTE*: The specified length is unitless. Unit is designated with the `payment_grace_period_unit` field. */
-      payment_grace_period_length?: number;
-      /** Flag that controls whether or not to invoice/charge a true up for a billing cycle on the following invoice. Only applies if invoice_fixed_components_at_start is enabled. */
-      invoice_overages?: boolean;
-      /** Time length unit of the grace period between the end of a billing cycle and invoice generation. Must be `day`. */
-      invoice_grace_period_unit?: 'day';
-      /** Optional description attached to the invoice */
-      invoice_memo?: string | null;
-      /** Time length unit of the grace period between the end of invoice generation and actual charge. One of `minute`, `hour`, `day`. */
-      payment_grace_period_unit?: string;
-      /** Flag that controls whether to invoice through Octane or through payment provider */
-      invoice_via_octane?: boolean;
-      /** Whether newly attached Stripe payment methods should be made the default for customers. */
-      auto_update_stripe_default_payment_method?: boolean | null;
-      /** Account name for ACH/Wire transfer instructions */
-      ach_account_name?: string | null;
+      /** Flag that controls whether to do automated taxes via payment provider */
+      tax_via_payment_provider?: boolean;
       /** Flag that controls whether to send receipts for paid invoices. */
       send_receipts?: boolean | null;
+      /** Second line of bank address for ACH/Wire transfer instructions */
+      ach_bank_address_2?: string | null;
+      /** List of days before an invoice is due to communicate upcoming due notices. */
+      upcoming_reminder_days_array?: number[] | null;
       /** Flag that controls whether or not to invoice/charge gauge meters upfront according to their value at start of cycle. Only applies if invoice_fixed_components_at_start is enabled. */
       invoice_metered_components_at_start?: boolean;
-      /** Flag that controls the number of retry attempts for invoicing/payments. */
-      retry_attempts?: number;
-      /** Flag determining whether ACH/Wire instructions should be included on invoices. */
-      include_ach_instructions?: boolean | null;
-      /** Flag that controls whether to communicate payment failures. */
-      communicate_payment_failures?: boolean | null;
-      /** Time length unit after which to attempt invoice/payment retry. */
-      retry_frequency_unit?: string;
-      /** Time length of the grace period between the end of a billing cycle and invoice generation in days. */
-      invoice_grace_period_length?: number;
-      /** If set, a minimum charge line item will override any line items that contribute to the minimum (i.e., the minimum charge line item would be the only line item). */
-      should_minimum_charge_override_line_items?: boolean | null;
-      /** Optional url of a custom image to include on invoices. */
-      invoice_logo_url?: string | null;
-      /** List of days after an invoice is due to communicate past due notices. */
-      past_due_reminder_days_array?: number[] | null;
-      /** If using stripe, this field can be used to configure whether invoices should be auto advanced for collection */
-      stripe_auto_advance?: boolean;
-      /** The percentage tax rate to apply to invoices. */
-      tax_rate?: number | null;
-      /** Flag that controls whether invoices are auto-approved or require manual approval */
-      auto_approve_invoices?: boolean;
-      /** Flag that controls whether or not to auto-charge the customer based on the invoice. */
-      charges_enabled?: boolean;
+      /** Whether newly attached Stripe payment methods should be made the default for customers. */
+      auto_update_stripe_default_payment_method?: boolean | null;
+      /** Flag that controls whether or not to invoice/charge the base rate, add ons and other fixed price plan components at the beginning of the billing cycle. */
+      invoice_fixed_components_at_start?: boolean;
+      /** Swift code for ACH/Wire transfer instructions */
+      ach_swift_code?: string | null;
+      customer_invoice_detail_level?: string;
       /** If using Stripe, this field can be used to configure whether invoices should be finalized immediately when they are created. */
       stripe_immediate_finalization?: boolean | null;
       /** ABA/Routing number for ACH/Wire transfer instructions */
       ach_routing_number?: string | null;
-      /** Second line of bank address for ACH/Wire transfer instructions */
-      ach_bank_address_2?: string | null;
-      /** Sets the due date on invoices to the number of days after the invoice is sent */
-      days_until_due?: number | null;
-      /** Time length after which to attempt invoice/payment retry. */
-      retry_frequency_length?: number;
-      /** True if customer updates should be synced to Stripe. */
-      sync_customer_data_to_payment_gateway?: boolean | null;
-      /** Flag that controls whether to do automated taxes via payment provider */
-      tax_via_payment_provider?: boolean;
-      /** List of days before an invoice is due to communicate upcoming due notices. */
-      upcoming_reminder_days_array?: number[] | null;
+      /** Time length unit of the grace period between the end of invoice generation and actual charge. One of `minute`, `hour`, `day`. */
+      payment_grace_period_unit?: string;
       /** Bank name for ACH/Wire transfer instructions */
       ach_bank_name?: string | null;
-      /** Swift code for ACH/Wire transfer instructions */
-      ach_swift_code?: string | null;
+      /** Flag determining whether ACH/Wire instructions should be included on invoices. */
+      include_ach_instructions?: boolean | null;
+      /** Flag that controls whether to invoice through Octane or through payment provider */
+      invoice_via_octane?: boolean;
+      /** Optional description attached to the invoice */
+      invoice_memo?: string | null;
       /** Flag that controls whether or not invoices should be sent to customers. */
       should_send_invoice_to_customers?: boolean;
-      /** Flag that controls whether or not to invoice/charge the base rate, add ons and other fixed price plan components at the beginning of the billing cycle. */
-      invoice_fixed_components_at_start?: boolean;
-      /** Default value for whether to align billing cycles to calendar on subscriptions */
-      align_billing_cycles_to_calendar?: boolean;
-      /** Account number for ACH/Wire transfer instructions */
-      ach_account_number?: string | null;
+      /** Flag that controls whether invoices are auto-approved or require manual approval */
+      auto_approve_invoices?: boolean;
       /** First line of bank address for ACH/Wire transfer instructions */
       ach_bank_address_1?: string | null;
+      /** Optional url of a custom image to include on invoices. */
+      invoice_logo_url?: string | null;
+      /** Account number for ACH/Wire transfer instructions */
+      ach_account_number?: string | null;
+      /** Flag that controls the number of retry attempts for invoicing/payments. */
+      retry_attempts?: number;
+      /** Flag that controls whether or not to auto-charge the customer based on the invoice. */
+      charges_enabled?: boolean;
+      /** Time length of the grace period between the end of invoice generation and the actual charge. *NOTE*: The specified length is unitless. Unit is designated with the `payment_grace_period_unit` field. */
+      payment_grace_period_length?: number;
+      /** Default value for whether to align billing cycles to calendar on subscriptions */
+      align_billing_cycles_to_calendar?: boolean;
+      /** Time length unit of the grace period between the end of a billing cycle and invoice generation. Must be `day`. */
+      invoice_grace_period_unit?: 'day';
+      /** List of days after an invoice is due to communicate past due notices. */
+      past_due_reminder_days_array?: number[] | null;
+      /** If set, a minimum charge line item will override any line items that contribute to the minimum (i.e., the minimum charge line item would be the only line item). */
+      should_minimum_charge_override_line_items?: boolean | null;
+      /** True if customer updates should be synced to Stripe. */
+      sync_customer_data_to_payment_gateway?: boolean | null;
+      /** Flag that controls whether to communicate payment failures. */
+      communicate_payment_failures?: boolean | null;
+      /** If using stripe, this field can be used to configure whether invoices should be auto advanced for collection */
+      stripe_auto_advance?: boolean;
+      /** The percentage tax rate to apply to invoices. */
+      tax_rate?: number | null;
+      /** Account name for ACH/Wire transfer instructions */
+      ach_account_name?: string | null;
+      /** Sets the due date on invoices to the number of days after the invoice is sent */
+      days_until_due?: number | null;
+      /** Time length of the grace period between the end of a billing cycle and invoice generation in days. */
+      invoice_grace_period_length?: number;
+      /** Time length unit after which to attempt invoice/payment retry. */
+      retry_frequency_unit?: string;
+      /** Time length after which to attempt invoice/payment retry. */
+      retry_frequency_length?: number;
+      /** Flag that controls whether or not to invoice/charge a true up for a billing cycle on the following invoice. Only applies if invoice_fixed_components_at_start is enabled. */
+      invoice_overages?: boolean;
     };
     Customer1: {
       /** Unique name identifier of a customer */
@@ -4310,17 +4340,17 @@ export interface components {
       discount_amount: number;
     };
     ApplyCouponInputArgs: {
+      vendor_id?: number;
+      customer_id?: number;
       name?: string;
       customer_name?: string;
       code?: string;
-      vendor_id?: number;
-      customer_id?: number;
     };
     CreateRefundArgs: {
-      /** Amount to be refunded */
-      amount?: number;
       /** Invoice that the refund should be against */
       invoice_id?: number;
+      /** Amount to be refunded */
+      amount?: number;
       /** Invoice that the refund should be against */
       invoice_uuid?: string;
     };
@@ -4334,9 +4364,9 @@ export interface components {
       price_plan_tags_filter?: string | null;
     };
     UpdateCustomerPortalSettingsInputArgs: {
-      price_plan_tags_filter?: string;
       price_plan_names_filter?: string;
       vendor_id?: number;
+      price_plan_tags_filter?: string;
     };
     CustomerPortalTokenInputArgs: {
       customer_name?: string;
@@ -4348,111 +4378,111 @@ export interface components {
       url?: string;
     };
     CustomerPortalVendor: {
+      /** Vendor's current payment gateway. */
+      payment_gateway?: string;
+      /** Full contact info for the Vendor */
+      contact_info?: components['schemas']['ContactInfo'];
       /** Currency preference of the Vendor. */
       currency?: string;
       /** Unique name identifier of a Vendor */
       name?: string;
       /** Display name for the Vendor */
       display_name?: string;
-      /** Full contact info for the Vendor */
-      contact_info?: components['schemas']['ContactInfo'];
-      /** Vendor's current payment gateway. */
-      payment_gateway?: string;
     };
     CustomerPortalInvoiceStatus: {
+      /** The current upcoming action associated with this invoice status, if any. */
+      action?: string;
+      /** Time the invoice status was last updated. */
+      updated_at?: string;
+      error?: string;
+      update_source?: string;
+      /** The current processing state for this invoice. */
+      status?: string;
       /** The timestamp that the action will be performed at. */
       pending_action_time?: string;
       /** Creation time of this invoice status. */
       created_at?: string;
-      /** The current processing state for this invoice. */
-      status?: string;
-      update_source?: string;
-      error?: string;
-      /** Time the invoice status was last updated. */
-      updated_at?: string;
-      /** The current upcoming action associated with this invoice status, if any. */
-      action?: string;
     };
     CustomerPortalInvoice: {
-      /** Any discount credits applied to the invoice */
-      discount_credit?: number;
-      /** Latest end time of line items covered by the invoice */
-      max_item_end_time?: string;
-      /** Amount due before any credits are applied */
-      sub_total?: number;
-      line_items?: components['schemas']['LineItems'][];
-      /** The date the invoice will be issued to the end customer or forwarded to the payment processor. */
-      issue_date?: string;
-      /** False if not paid yet */
-      is_paid?: boolean;
-      /** Total amount due */
-      amount_due?: number;
-      /** Url pointing to the pdf of this invoice. */
-      pdf_url?: string;
-      /** Earliest start time of line items covered by the invoice */
-      min_item_start_time?: string;
-      /** [DEPRECATED] End time of the cycle in which the invoice was generated */
-      end_time?: string;
-      due_date?: string;
-      /** Information related to the current status of this invoice. */
-      status?: components['schemas']['CustomerPortalInvoiceStatus'];
       /** Tax amount applied to subtotal */
       tax_amount?: number;
+      /** Url pointing to the pdf of this invoice. */
+      pdf_url?: string;
+      /** Total amount due */
+      amount_due?: number;
+      /** False if not paid yet */
+      is_paid?: boolean;
+      id?: string;
+      /** The date the invoice will be issued to the end customer or forwarded to the payment processor. */
+      issue_date?: string;
+      due_date?: string;
+      /** Amount due before any credits are applied */
+      sub_total?: number;
+      /** Any discount credits applied to the invoice */
+      discount_credit?: number;
+      /** Information related to the current status of this invoice. */
+      status?: components['schemas']['CustomerPortalInvoiceStatus'];
       /** [DEPRECATED] Start time of the cycle in which the invoice was generated */
       start_time?: string;
-      id?: string;
+      line_items?: components['schemas']['LineItems'][];
+      /** Earliest start time of line items covered by the invoice */
+      min_item_start_time?: string;
+      /** Latest end time of line items covered by the invoice */
+      max_item_end_time?: string;
+      /** [DEPRECATED] End time of the cycle in which the invoice was generated */
+      end_time?: string;
     };
     CustomerPortalActiveSubscription: {
       /** Customer's current active subscription. Includes the price plan and overrides they are subscribed to. */
       subscription?: components['schemas']['Subscription'];
+      /** The date that the customer will be invoiced for their current billing cycle. */
+      invoicing_date?: string;
       /** Customer's current active biling cycle. */
       billing_cycle: components['schemas']['BillingCycleDate'];
       /** The total fixed price the customer will be charged for this billing cycle. Includes the base price and any add ons. */
       total_fixed_price?: number;
-      /** The date that the customer will be invoiced for their current billing cycle. */
-      invoicing_date?: string;
       /** The total fixed price with all discounts applied. */
       discounted_fixed_price?: number;
     };
     CustomerPortalActiveSubscriptionInputArgs: {
-      /** Price plan uuid to subscribe to. */
-      price_plan_uuid?: string;
-      /** Add ons to include in subscription. */
-      add_ons?: components['schemas']['SubscriptionAddOnInput'][] | null;
       /** Customer name. Required only if using vendor API Key for authentication. */
       customer_name?: string;
+      /** Add ons to include in subscription. */
+      add_ons?: components['schemas']['SubscriptionAddOnInput'][] | null;
+      /** Price plan uuid to subscribe to. */
+      price_plan_uuid?: string;
     };
     CustomerPortalSubscription: {
       price_plan?: components['schemas']['PricePlan'];
     };
     CustomerPortalSubscriptionInputArgs: {
+      /** Customer name. Required only if using vendor API Key for authentication. */
+      customer_name?: string;
       /** Price plan name to subscribe to. */
       price_plan_name?: string;
-      /** Customer name. Required only if using vendor API Key for authentication. */
-      customer_name?: string;
     };
     CustomerPortalStripeCredential: {
+      account_id?: string;
       client_secret?: string;
       publishable_key?: string;
-      account_id?: string;
     };
     CustomerPortalContactInfoInputArgs: {
-      email?: string | null;
-      address_line_1?: string | null;
-      /** Customer name. Required only if using vendor API Key for authentication. */
-      customer_name?: string;
       state?: string | null;
+      zipcode?: string | null;
       /** List of secondary contact emails (all email communication will also be sent to these emails). */
       secondary_emails?: string[] | null;
       phone?: string | null;
-      country?: string | null;
-      address_line_2?: string | null;
-      logo_url?: string | null;
       vat_id?: string | null;
-      city?: string | null;
-      zipcode?: string | null;
-      url?: string | null;
+      address_line_1?: string | null;
+      logo_url?: string | null;
+      email?: string | null;
       legal_name?: string | null;
+      address_line_2?: string | null;
+      /** Customer name. Required only if using vendor API Key for authentication. */
+      customer_name?: string;
+      url?: string | null;
+      city?: string | null;
+      country?: string | null;
     };
     CustomerPortalMeterLabels: {
       key?: string;
@@ -4471,31 +4501,24 @@ export interface components {
       values?: components['schemas']['CustomerPortalLabelDisplayName'][];
     };
     CustomerPortalMeter: {
-      /** Display name of the meter. */
-      meter_display_name?: string;
-      /** Name of the unit the meter uses. */
-      unit_name?: string;
       /** Aggregation of meter. E.g. SUM, TIME_WEIGHTED_SUM, MAX, or LATEST. */
       aggregation?: string;
-      /** Primary labels with keys and values */
-      labels?: components['schemas']['CustomerPortalMeterLabels'][];
-      /** The raw and prettified label keys and values */
-      labels_with_display_names?: components['schemas']['CustomerPortalMeterLabelsWithDisplayName'][];
-      /** Type of the meter. E.g. COUNTER or GAUGE. */
-      meter_type?: string;
       /** Type of meter data. E.g. DISCRETE or CONTINUOUS. */
       data_type?: string;
+      /** Primary labels with keys and values */
+      labels?: components['schemas']['CustomerPortalMeterLabels'][];
+      /** Name of the unit the meter uses. */
+      unit_name?: string;
+      /** The raw and prettified label keys and values */
+      labels_with_display_names?: components['schemas']['CustomerPortalMeterLabelsWithDisplayName'][];
+      /** Display name of the meter. */
+      meter_display_name?: string;
+      /** Type of the meter. E.g. COUNTER or GAUGE. */
+      meter_type?: string;
       /** Name of the meter. */
       meter_name?: string;
     };
     CustomerPortalAccruedRevenueLineItem: {
-      /**
-       * Any extra metadata associated with the item.
-       *         Will include the labels for metered components and metered component minimum charges when applicable
-       */
-      metadata?: { [key: string]: string };
-      /** Accrued revenue for this line item in cents */
-      revenue?: number;
       /**
        * The identifier of the item being returned.
        *         For metered component will be meter name,
@@ -4505,108 +4528,115 @@ export interface components {
        *         for metered component minimum charge will be meter name
        */
       item_identifier?: string;
+      /**
+       * Any extra metadata associated with the item.
+       *         Will include the labels for metered components and metered component minimum charges when applicable
+       */
+      metadata?: { [key: string]: string };
+      /** Accrued revenue for this line item in cents */
+      revenue?: number;
       /** Type of item. One of: METERED_COMPONENT, BASE_PRICE, DISCOUNT, ADD_ON, MINIMUM_CHARGE, METERED_COMPONENT_MINIMUM_CHARGE */
       item_type?: string;
     };
     CustomerPortalAccruedRevenue: {
       line_items?: components['schemas']['CustomerPortalAccruedRevenueLineItem'][];
-      /** The cycle start of the billing cycle for which the accrued revenue is computed */
-      start_time?: string;
       /** Total accrued revenue for the period in cents */
       total_accrued_revenue?: number;
+      /** The cycle start of the billing cycle for which the accrued revenue is computed */
+      start_time?: string;
       /** The end time within the billing cycle for which this accrued revenue is computed */
       end_time?: string;
     };
     CustomerPortalDailyAccruedRevenue: {
+      /** The date for which this accrued revenue is computed */
+      date?: string;
+      /** Total accrued revenue for the day in cents */
+      total_accrued_revenue?: number;
+      /** The start time of the billing cycle for which the accrued revenue is computed */
+      start_time?: string;
       line_items?: components['schemas']['CustomerPortalAccruedRevenueLineItem'][];
       /** The end time till when the accrued revenue is computed */
       end_time?: string;
-      /** Total accrued revenue for the day in cents */
-      total_accrued_revenue?: number;
-      /** The date for which this accrued revenue is computed */
-      date?: string;
-      /** The start time of the billing cycle for which the accrued revenue is computed */
-      start_time?: string;
     };
     CustomerPortalLabelFilter: {
-      key: string;
       /** Primary label value associated with the key */
       value: string;
+      key: string;
     };
     CustomerPortalMeterLabelFilter: {
+      /** Primary labels with keys and values */
+      label_filters?: components['schemas']['CustomerPortalLabelFilter'][];
+      /** [DEPRECATED] Please use label_group_by_keys instead. */
+      label_group_by?: string;
+      /** The aggregate function to use for the meter. */
+      aggregate?: 'sum' | 'time_weighted' | 'latest' | 'max';
       /** Customer name. Required only if using vendor API Key for authentication. */
       customer_name?: string;
       /** A list of primary label keys to group results by. */
       label_group_by_keys?: string[];
       /** Name of the meter. */
       meter_name: string;
-      /** [DEPRECATED] Please use label_group_by_keys instead. */
-      label_group_by?: string;
-      /** The aggregate function to use for the meter. */
-      aggregate?: 'sum' | 'time_weighted' | 'latest' | 'max';
-      /** Primary labels with keys and values */
-      label_filters?: components['schemas']['CustomerPortalLabelFilter'][];
     };
     DailyUsage: {
-      /** Start of the 24 hour time window in UTC. */
-      time?: string;
-      /** [DEPRECATED] Please use labels field instead. */
-      label_key?: string;
       /** Labels for this usage. Only present if label_group_by_keys is provided. */
       labels?: { [key: string]: string };
-      /** Total usage during this window. */
+      /** Start of the 24 hour time window in UTC. */
+      time?: string;
+      /** Total usage during this window. Rounded to 6 decimal places. */
       usage?: number;
       /** [DEPRECATED] Please use labels field instead. */
       label_value?: string;
+      /** [DEPRECATED] Please use labels field instead. */
+      label_key?: string;
     };
     CycleUsage: {
-      /** Total usage in the cycle. */
-      total_usage?: number;
       /** The end of the billing cycle in UTC. */
       cycle_end?: string;
+      /** Total usage in the cycle. Rounded to 6 decimal places. */
+      total_usage?: number;
+      usage_by_time?: components['schemas']['DailyUsage'][];
       /** The start of the billing cycle in UTC. */
       cycle_start?: string;
-      usage_by_time?: components['schemas']['DailyUsage'][];
     };
     CustomerPortalUsage: {
-      /** Display name of the meter. */
-      meter_display_name?: string;
-      /** Name of the unit the meter uses. */
-      unit_name?: string;
-      /** Type of the meter. E.g. COUNTER or GAUGE. */
-      meter_type?: string;
       /** Daily usage across the current billing cycle. */
       current_cycle_usage?: components['schemas']['CycleUsage'];
-      /** Daily usage across the previous billing cycle. */
-      previous_cycle_usage?: components['schemas']['CycleUsage'];
+      /** Name of the unit the meter uses. */
+      unit_name?: string;
+      /** Display name of the meter. */
+      meter_display_name?: string;
+      /** Type of the meter. E.g. COUNTER or GAUGE. */
+      meter_type?: string;
       /** Name of the meter. */
       meter_name?: string;
+      /** Daily usage across the previous billing cycle. */
+      previous_cycle_usage?: components['schemas']['CycleUsage'];
     };
     BankAccountInfo: {
+      /** Routing number for the bank accopunt */
+      routing_number?: number;
       /** Name of the bank */
       bank_name?: string;
       /** Last 4 digits of the bank account number. */
       last4?: string;
-      /** Country the bank account is in. */
-      country?: string;
       external_id?: string;
-      /** Routing number for the bank accopunt */
-      routing_number?: number;
       /** Bank account type. E.g. Savings/Checking */
       account_type?: string;
+      /** Country the bank account is in. */
+      country?: string;
     };
     CardInfo: {
-      /** Brand of card. E.g. Amex, Visa, etc. */
-      brand?: string;
-      /** Country of the card */
-      country?: string;
-      /** Last 4 digits of the card. */
-      last4?: string;
       /** Year the card expires */
       exp_year?: number;
+      /** Brand of card. E.g. Amex, Visa, etc. */
+      brand?: string;
       /** Month the card expires */
       exp_month?: number;
+      /** Last 4 digits of the card. */
+      last4?: string;
       external_id?: string;
+      /** Country of the card */
+      country?: string;
     };
     CustomerPortalPaymentMethod: {
       /** Info about the customer's US bank account, if that is their payment method. */
@@ -4637,43 +4667,43 @@ export interface components {
       settings: { [key: string]: string };
     };
     CreditLedger: {
+      /** The time at which this credit balance change occurred. */
+      timestamp?: string;
       pending?: boolean;
       /** The change in numer of credits */
       amount?: number;
       /** Credit balance as of this change */
       balance?: number;
-      /** The time at which this credit balance change occurred. */
-      timestamp?: string;
     };
     CustomerPortalAvailableCreditBalance: {
       /** The start_time used for calculating this available balance. */
       start_time?: string;
-      /** Available credit balance. */
-      available_balance?: number;
       /** The end_time used for calculating this available balance. */
       end_time?: string;
+      /** Available credit balance. */
+      available_balance?: number;
     };
     CustomerPortalCreditPurchase: {
-      /** Number of credits to purchase. */
-      amount: number;
       /** Customer name. Required only if using vendor API Key for authentication. */
       customer_name?: string;
+      /** Number of credits to purchase. */
+      amount: number;
     };
     CreditGrant: {
-      /** Name of the customer who received the grant */
-      customer_name?: string;
-      /** The date at which this grant expires */
-      expires_at?: string;
       /** Number of credits granted */
       amount?: number;
-      /** The source of the grant. */
-      source?: string;
-      /** Total price paid for the credits, in cents */
-      price?: number;
       /** Optional description. This is only viewable internally */
       description?: string;
       /** A unique identifier for this grant */
       uuid?: string;
+      /** Total price paid for the credits, in cents */
+      price?: number;
+      /** The date at which this grant expires */
+      expires_at?: string;
+      /** Name of the customer who received the grant */
+      customer_name?: string;
+      /** The source of the grant. */
+      source?: string;
       /** The date at which this grant is effective */
       effective_at?: string;
     };
@@ -4686,49 +4716,49 @@ export interface components {
       enable_signature: boolean;
     };
     CreateWebhookArgs: {
-      url?: string;
       enable_signature?: boolean;
+      url?: string;
     };
     ListCreditGrantsArgs: {
-      /** The number of items to fetch. Defaults to 10. */
-      limit?: number;
+      sort_direction?: string;
+      /** The sort column offset to start at when paging forwards */
+      forward_sort_offset?: string;
       /** The unique offset to start at when paging forwards */
       forward_secondary_sort_offset?: string;
       sort_column?: string;
       /** Customer to filter the results to */
       customer_name?: string;
+      /** The number of items to fetch. Defaults to 10. */
+      limit?: number;
+    };
+    ListCreditGrants: {
       sort_direction?: string;
       /** The sort column offset to start at when paging forwards */
       forward_sort_offset?: string;
-    };
-    ListCreditGrants: {
-      /** The number of items to fetch. Defaults to 10. */
-      limit?: number;
       /** The unique offset to start at when paging forwards */
       forward_secondary_sort_offset?: string;
       sort_column?: string;
       credit_grants?: components['schemas']['CreditGrant'][];
-      sort_direction?: string;
-      /** The sort column offset to start at when paging forwards */
-      forward_sort_offset?: string;
+      /** The number of items to fetch. Defaults to 10. */
+      limit?: number;
     };
     CreateCreditGrantArgs: {
+      /** Time length unit for the default expiration for credits granted in a top off. */
+      expiration_unit?: string;
+      /** Number of credits to grant */
+      amount: number;
       /** Time length of the default expiration for credits granted in a top off. */
       expiration_length?: number;
-      /** Name of the customer receving the grant */
-      customer_name: string;
+      /** Optional description. This is only viewable internally */
+      description?: string;
+      /** Total price paid for the credits in cents. Defaults to $1 (100 cents) per credit if not specified */
+      price?: number;
       /** The date at which this grant expires */
       expires_at?: string;
       /** Determines whether to synchronously create an invoice and charge the customer */
       charge_immediately?: boolean;
-      /** Number of credits to grant */
-      amount: number;
-      /** Total price paid for the credits in cents. Defaults to $1 (100 cents) per credit if not specified */
-      price?: number;
-      /** Optional description. This is only viewable internally */
-      description?: string;
-      /** Time length unit for the default expiration for credits granted in a top off. */
-      expiration_unit?: string;
+      /** Name of the customer receving the grant */
+      customer_name: string;
       /** The date at which the grant is effective */
       effective_at?: string;
     };
@@ -4743,93 +4773,93 @@ export interface components {
       api_key: string;
     };
     RollApiKeys: {
+      success?: boolean;
       /** The newly generated API Key. */
       api_key?: string;
-      success?: boolean;
     };
     UpdateSelfServeSettingsArgs: {
-      /** True if the customer can switch their current price plan via self serve. Defaults to False. */
-      switch_price_plans?: boolean;
-      /** True if the vendor has enabled customization for their customer portal. */
-      customization?: boolean;
-      /** Time length unit for the default expiration for credits bought in the customer portal. */
-      credits_expiration_unit?: string;
-      /** True if the vendor has enabled customization for their customer portal. */
-      enabled?: boolean;
       /** True if payment form should have fields for shipping address info. Defaults to False. */
       enable_address_fields?: boolean;
-      /** True if the customer can purchase credits via self serve. Defaults to False. */
-      purchase_credits?: boolean;
       /** Price per credit, in cents, that the customer is charged for buying credits through the customer portal */
       price_per_credit_cents?: number;
       /** Time length of the default expiration for credits bought in the customer portal. */
       credits_expiration_length?: number;
+      /** True if the customer can purchase credits via self serve. Defaults to False. */
+      purchase_credits?: boolean;
+      /** True if the vendor has enabled customization for their customer portal. */
+      customization?: boolean;
+      /** True if the customer can switch their current price plan via self serve. Defaults to False. */
+      switch_price_plans?: boolean;
+      /** True if the vendor has enabled customization for their customer portal. */
+      enabled?: boolean;
+      /** Time length unit for the default expiration for credits bought in the customer portal. */
+      credits_expiration_unit?: string;
     };
     VendorAvalaraSettings: {
-      /** True if enabling logging for Avalara calls, false otherwise. */
-      enable_logging?: boolean;
-      /** True if the documents generated in Avalara should be committed, false otherwise. */
-      commit_documents?: boolean;
-      /** Password of the Avalara account. */
-      password?: string;
-      /** The Avalara company code string to associate the Octane vendor with. */
-      company_code?: string;
-      /** The Avalara item code to use to represent all the line items on the Octane invoice. */
-      item_code?: string;
-      /** he tax code to associate with the item that is representing the Octane invoice. */
-      tax_code?: string;
-      /** The item description to use to represent all the lines on the Octane invoice. */
-      item_description?: string;
       /** Username of the Avalara account. */
       username?: string;
+      /** The Avalara item code to use to represent all the line items on the Octane invoice. */
+      item_code?: string;
+      /** The item description to use to represent all the lines on the Octane invoice. */
+      item_description?: string;
       /** True if connecting to Avalara sandbox account, false otherwise. */
       sandbox_mode?: boolean;
-      /** Enable/Disable the Avalara integration. */
-      enable_integration?: boolean;
-    };
-    CreateVendorAvalaraSettingsArgs: {
-      /** True if enabling logging for Avalara calls, false otherwise. Defaults to False. */
-      enable_logging?: boolean;
-      /** True if the documents generated in Avalara should be committed, false otherwise. Defaults to False. */
-      commit_documents?: boolean;
       /** Password of the Avalara account. */
-      password: string;
-      /** The Avalara company code string to associate the Octane vendor with. */
-      company_code?: string;
-      /** The Avalara item code to use to represent all the line items on the Octane invoice. */
-      item_code?: string;
-      /** The tax code to associate with the item that is representing the Octane invoice. */
-      tax_code?: string;
-      /** The item description to use to represent all the lines on the Octane invoice. */
-      item_description?: string;
-      /** Username of the Avalara account. */
-      username: string;
-      /** True if connecting to Avalara sandbox account, false otherwise. */
-      sandbox_mode: boolean;
-      /** Enable/Disable the Avalara integration. */
-      enable_integration: boolean;
-    };
-    UpdateVendorAvalaraSettingsArgs: {
+      password?: string;
       /** True if enabling logging for Avalara calls, false otherwise. */
       enable_logging?: boolean;
-      /** True if the documents generated in Avalara should be committed, false otherwise. */
-      commit_documents?: boolean;
-      /** The Avalara item code to use to represent all the line items on the Octane invoice. */
-      item_code?: string;
-      /** The Avalara company code string to associate the Octane vendor with. */
-      company_code?: string;
       /** he tax code to associate with the item that is representing the Octane invoice. */
       tax_code?: string;
-      /** The item description to use to represent all the lines on the Octane invoice. */
-      item_description?: string;
+      /** True if the documents generated in Avalara should be committed, false otherwise. */
+      commit_documents?: boolean;
       /** Enable/Disable the Avalara integration. */
       enable_integration?: boolean;
+      /** The Avalara company code string to associate the Octane vendor with. */
+      company_code?: string;
+    };
+    CreateVendorAvalaraSettingsArgs: {
+      /** Username of the Avalara account. */
+      username: string;
+      /** The Avalara item code to use to represent all the line items on the Octane invoice. */
+      item_code?: string;
+      /** The item description to use to represent all the lines on the Octane invoice. */
+      item_description?: string;
+      /** True if connecting to Avalara sandbox account, false otherwise. */
+      sandbox_mode: boolean;
+      /** Password of the Avalara account. */
+      password: string;
+      /** True if enabling logging for Avalara calls, false otherwise. Defaults to False. */
+      enable_logging?: boolean;
+      /** The tax code to associate with the item that is representing the Octane invoice. */
+      tax_code?: string;
+      /** True if the documents generated in Avalara should be committed, false otherwise. Defaults to False. */
+      commit_documents?: boolean;
+      /** Enable/Disable the Avalara integration. */
+      enable_integration: boolean;
+      /** The Avalara company code string to associate the Octane vendor with. */
+      company_code?: string;
+    };
+    UpdateVendorAvalaraSettingsArgs: {
+      /** The Avalara item code to use to represent all the line items on the Octane invoice. */
+      item_code?: string;
+      /** The item description to use to represent all the lines on the Octane invoice. */
+      item_description?: string;
+      /** True if enabling logging for Avalara calls, false otherwise. */
+      enable_logging?: boolean;
+      /** he tax code to associate with the item that is representing the Octane invoice. */
+      tax_code?: string;
+      /** True if the documents generated in Avalara should be committed, false otherwise. */
+      commit_documents?: boolean;
+      /** Enable/Disable the Avalara integration. */
+      enable_integration?: boolean;
+      /** The Avalara company code string to associate the Octane vendor with. */
+      company_code?: string;
     };
     ValidateCredentialsArgs: {
-      /** Password of the Avalara account */
-      password: string;
       /** True if using a Avalara sandbox account, False otherwise */
       sandbox_mode: boolean;
+      /** Password of the Avalara account */
+      password: string;
       /** Username of the Avalara account */
       username: string;
     };
@@ -4838,50 +4868,50 @@ export interface components {
       success?: boolean;
     };
     TaxCode: {
-      /** A code string that identifies this tax code. */
-      tax_code?: string;
+      /** The unique ID number of this tax code. */
+      id?: string;
       /** The Avalara Entity Use Code represented by this tax code. */
       entity_use_code?: string;
       /** The type of this tax code. */
       tax_code_type_id?: string;
-      /** The unique ID number of this tax code. */
-      id?: string;
       /** A friendly description of this tax code. */
       description?: string;
+      /** A code string that identifies this tax code. */
+      tax_code?: string;
     };
     Company: {
       /** The name of this company, as shown to customers. */
       company_name?: string;
-      /** A unique code that references this company within your account. */
-      company_code?: string;
-      /** This flag indicates whether tax activity can occur for this company. */
-      is_active?: boolean;
-      /** This flag is true if this company is the default company for this account. */
-      is_default?: boolean;
       /** The unique ID number of this company. */
       id?: string;
+      /** This flag is true if this company is the default company for this account. */
+      is_default?: boolean;
+      /** This flag indicates whether tax activity can occur for this company. */
+      is_active?: boolean;
+      /** A unique code that references this company within your account. */
+      company_code?: string;
     };
     EntityUseCode: {
+      /** The Avalara-recognized entity use code for this definition. */
+      code?: string;
+      /** The name of this entity use code. */
+      name?: string;
       /** Text describing the meaning of this use code. */
       description?: string;
       /** A list of countries where this use code is valid. */
       valid_countries?: string[];
-      /** The name of this entity use code. */
-      name?: string;
-      /** The Avalara-recognized entity use code for this definition. */
-      code?: string;
     };
     RevenueRecognitionInput: {
       /** List of customer names for which to compute booked/recognized revenue. */
       customer_names?: string[];
     };
     RevenueRecognitionEntry: {
-      /** The change in recognized revenue this month (in cents). */
-      recognized?: number;
-      /** The month in which the revenue is booked and(or) recognized. */
-      month?: string;
       /** The newly booked amount in this month (in cents). */
       booked?: number;
+      /** The month in which the revenue is booked and(or) recognized. */
+      month?: string;
+      /** The change in recognized revenue this month (in cents). */
+      recognized?: number;
       /** The change in deferred revenue this month (in cents). */
       deferred?: number;
     };

--- a/src/hooks/useDailyAccruedRevenue.tsx
+++ b/src/hooks/useDailyAccruedRevenue.tsx
@@ -1,0 +1,37 @@
+import { useCallback, useContext } from 'react';
+import { useAsync } from './useAsync';
+import type { UseAsyncFetchReturnType } from './useAsync';
+import { TokenContext } from './useCustomerToken';
+import { components } from '../apiTypes';
+import getCustomerDailyAccruedRevenue from '../actions/getCustomerDailyAccruedRevenue';
+
+type CustomerDailyAccruedRevenue =
+  components['schemas']['CustomerPortalDailyAccruedRevenue'][];
+
+export type UseDailyAccruedRevenueReturnType =
+  UseAsyncFetchReturnType<CustomerDailyAccruedRevenue>;
+
+/**
+ * @description
+ * A hook that fetches customer's daily accrued revenue data.
+ * @example
+ * const { result, loading, error, refetch } = useDailyAccruedRevenue({ token });
+ */
+export const useDailyAccruedRevenue = (args?: {
+  token?: string;
+  baseApiUrl?: string;
+}): UseDailyAccruedRevenueReturnType => {
+  const { token: tokenFromContext } = useContext(TokenContext);
+  const userToken = args?.token || tokenFromContext;
+  const baseApiUrl = args?.baseApiUrl;
+
+  if (!userToken) {
+    throw new Error('Token must be provided.');
+  }
+
+  const fetchFn = useCallback(() => {
+    return getCustomerDailyAccruedRevenue(userToken, { baseApiUrl });
+  }, [userToken, baseApiUrl]);
+
+  return useAsync({ fetchFn });
+};

--- a/src/hooks/useTotalAccruedRevenue.tsx
+++ b/src/hooks/useTotalAccruedRevenue.tsx
@@ -1,0 +1,37 @@
+import { useCallback, useContext } from 'react';
+import { useAsync } from './useAsync';
+import type { UseAsyncFetchReturnType } from './useAsync';
+import { TokenContext } from './useCustomerToken';
+import { components } from '../apiTypes';
+import getCustomerTotalAccruedRevenue from '../actions/getCustomerTotalAccruedRevenue';
+
+type CustomerTotalAccruedRevenue =
+  components['schemas']['CustomerPortalAccruedRevenue'];
+
+export type UseTotalAccruedRevenueReturnType =
+  UseAsyncFetchReturnType<CustomerTotalAccruedRevenue>;
+
+/**
+ * @description
+ * A hook that fetches customer's total accrued revenue data.
+ * @example
+ * const { result, loading, error, refetch } = useTotalAccruedRevenue({ token });
+ */
+export const useTotalAccruedRevenue = (args?: {
+  token?: string;
+  baseApiUrl?: string;
+}): UseTotalAccruedRevenueReturnType => {
+  const { token: tokenFromContext } = useContext(TokenContext);
+  const userToken = args?.token || tokenFromContext;
+  const baseApiUrl = args?.baseApiUrl;
+
+  if (!userToken) {
+    throw new Error('Token must be provided.');
+  }
+
+  const fetchFn = useCallback(() => {
+    return getCustomerTotalAccruedRevenue(userToken, { baseApiUrl });
+  }, [userToken, baseApiUrl]);
+
+  return useAsync({ fetchFn });
+};


### PR DESCRIPTION
## Why do we need this change?

Added new hooks/actions:
- `useTotalAccruedRevenue` - to get total accrued revenue data broken down by line item
- `useDailyAccruedRevenue` - to get daily accrued revenue data for a customer broken down by line item

## What changes are in this PR?

_This is a good place to put any screenshots._

## How has this change been tested?

_Did you add any tests?_

## Any notes or requests for specific feedback?

_If not, feel free to delete this section._
